### PR TITLE
Allow config paramters to be passed via env vars

### DIFF
--- a/tests/integration/test_pinecone.py
+++ b/tests/integration/test_pinecone.py
@@ -26,7 +26,9 @@ def api_key():
     return host
 
 
-def spawn_ysb(workload, api_key, index_name, timeout=60, extra_args=[]):
+def spawn_vsb(workload, api_key, index_name, timeout=60, extra_args=[]):
+    env = os.environ
+    env.update({"VSB__PINECONE_API_KEY": api_key})
     proc = subprocess.Popen(
         [
             "./vsb.py",
@@ -34,14 +36,13 @@ def spawn_ysb(workload, api_key, index_name, timeout=60, extra_args=[]):
             "pinecone",
             "--workload",
             workload,
-            "--api_key",
-            api_key,
-            "--index_name",
+            "--pinecone_index_name",
             index_name,
         ]
         + extra_args,
         stdout=PIPE,
         stderr=PIPE,
+        env=env,
         text=True,
     )
     try:
@@ -65,8 +66,8 @@ def spawn_ysb(workload, api_key, index_name, timeout=60, extra_args=[]):
 class TestPinecone:
     def test_mnist(self, api_key, index_name):
         # Test "-test" variant of mnist loads and runs successfully.
-        (proc, stdout, stderr) = spawn_ysb(
+        (proc, stdout, stderr) = spawn_vsb(
             workload="mnist-test", api_key=api_key, index_name=index_name
         )
-        # TODO: Check more here when ysb output is more structured.
+        # TODO: Check more here when vsb output is more structured.
         assert proc.returncode == 0

--- a/vsb/databases/__init__.py
+++ b/vsb/databases/__init__.py
@@ -9,14 +9,14 @@ class Database(Enum):
     Pinecone = "pinecone"
     PGVector = "pgvector"
 
-    def build(self, config: dict) -> DB:
-        """Construct an instance of DB based on the database enum value"""
+    def get_class(self) -> type[DB]:
+        """Return the DB class to use, based on the value of the enum"""
         match self:
             case Database.Pinecone:
                 from .pinecone.pinecone import PineconeDB
 
-                return PineconeDB(config)
+                return PineconeDB
             case Database.PGVector:
                 from .pgvector.pgvector import PGVectorDB
 
-                return PGVectorDB()
+                return PGVectorDB

--- a/vsb/databases/pinecone/pinecone.py
+++ b/vsb/databases/pinecone/pinecone.py
@@ -13,7 +13,6 @@ class PineconeIndex(Index):
         raise NotImplementedError
 
     def upsert_batch(self, batch: list[Record]):
-
         self.index.upsert(batch)
 
     def search(self, request: SearchRequest) -> list[str]:
@@ -23,9 +22,9 @@ class PineconeIndex(Index):
 
 
 class PineconeDB(DB):
-    def __init__(self, config: dict):
-        self.pc = PineconeGRPC(config["api_key"])
-        self.index = self.pc.Index(name=config["index_name"])
+    def __init__(self, config):
+        self.pc = PineconeGRPC(config.pinecone_api_key)
+        self.index = self.pc.Index(name=config.pinecone_index_name)
 
     def get_index(self, tenant: str) -> Index:
         return PineconeIndex(self.index, tenant)


### PR DESCRIPTION
## Problem

Sensitive arguments (e.g. API_KEYS, passwords) should not be passed on
the command-line as arguments can easily be leaked (any user can see
the arguments of all processes). Instead we should allow them to be
passed via env var.

## Solution

Modify the config parsing to use the configargparse module (as used by
locust itself) instead of argparse module, as configargparse supports
passing via env var. Add env vars to all optional arguments with the
format 'VSB__CONFIG_NAME'.

Closes #13.

