### PR TITLE
Rename Index -> Namespace

### DIFF
--- a/vsb.py
+++ b/vsb.py
@@ -60,7 +60,7 @@ class VectorSearchUser(User):
         try:
             (tenant, vectors) = self.workload.next_record_batch()
             if vectors:
-                index = self.database.get_index(tenant)
+                index = self.database.get_namespace(tenant)
 
                 start = time.perf_counter()
                 index.upsert_batch(vectors)
@@ -85,7 +85,7 @@ class VectorSearchUser(User):
         (tenant, request) = self.workload.next_request()
         if request:
             try:
-                index = self.database.get_index(tenant)
+                index = self.database.get_namespace(tenant)
 
                 start = time.perf_counter()
                 index.search(request)

--- a/vsb/databases/base.py
+++ b/vsb/databases/base.py
@@ -4,12 +4,15 @@ from enum import Enum, auto
 from vsb.vsb_types import Record, SearchRequest
 
 
-class Index(ABC):
-    """Abstract class with represents an index or one or more vector records.
+class Namespace(ABC):
+    """Abstract class with represents a set of one or more vector records
+    grouped together by some logical association (e.g. a single tenant / user).
+    A Database consists of one or more Namespaces, and each record exists
+    in exactly one namespace.
     Specific implementations should subclass this and implement all abstract
     methods.
     Instance of this (derived) class are typically created via the corresponding
-    (concrete) DB create_index() method.
+    (concrete) DB get_namespace() method.
     """
 
     @abstractmethod
@@ -26,11 +29,12 @@ class Index(ABC):
 
 
 class DB(ABC):
-    """Abstract class which represents a database which can store vector
-    records in one or more Indexes. Specific Vector DB implementations should
-    subclass this and implement all abstract methods.
+    """Abstract class which represents a vector database made up of one or more
+    Namespaces, where each Namespace contains one or more records.
+
+    Specific Vector DB implementations should subclass this and implement all abstract methods.
     """
 
     @abstractmethod
-    def get_index(self, tenant: str) -> Index:
+    def get_namespace(self, namespace_name: str) -> Namespace:
         raise NotImplementedError

--- a/vsb/databases/pinecone/pinecone.py
+++ b/vsb/databases/pinecone/pinecone.py
@@ -1,12 +1,12 @@
 from pinecone.grpc import PineconeGRPC, GRPCIndex
 
-from ..base import DB, Index
+from ..base import DB, Namespace
 from ...vsb_types import Vector, Record, SearchRequest
 
 
-class PineconeIndex(Index):
-    def __init__(self, index: GRPCIndex, tenent: str):
-        # TODO: Support multiple indexes (namesspaces)
+class PineconeNamespace(Namespace):
+    def __init__(self, index: GRPCIndex, namespace: str):
+        # TODO: Support multiple namespaces
         self.index = index
 
     def upsert(self, ident, vector, metadata):
@@ -26,5 +26,5 @@ class PineconeDB(DB):
         self.pc = PineconeGRPC(config.pinecone_api_key)
         self.index = self.pc.Index(name=config.pinecone_index_name)
 
-    def get_index(self, tenant: str) -> Index:
-        return PineconeIndex(self.index, tenant)
+    def get_namespace(self, namespace: str) -> Namespace:
+        return PineconeNamespace(self.index, namespace)

--- a/vsb/workloads/parquet_workload/parquet_workload.py
+++ b/vsb/workloads/parquet_workload/parquet_workload.py
@@ -2,7 +2,6 @@ from abc import ABC
 
 from ..base import VectorWorkload
 from ..dataset import Dataset
-from ...databases.base import Index
 from ...vsb_types import Record, SearchRequest
 
 
@@ -25,10 +24,6 @@ class ParquetWorkload(VectorWorkload, ABC):
 
         self.dataset.setup_queries(load_queries=True, query_limit=query_limit)
         self.queries = self.dataset.queries.itertuples(index=False)
-
-        # Map of index tenants to the Index instance. Lazily populated as
-        # requests are accessed for a particular tenant.
-        self.indexes = dict()
 
     def next_record_batch(self) -> (str, list[Record]):
         try:


### PR DESCRIPTION
## Problem

'Index' is somewhat ambiguous - does it refer to the overall 'thing'
we are connecting to (database), or does it refer to a logical
subdivision (namespace)?

## Solution

Rename to Namespace (the Pinecone nomenclature). Alternatives would be
'collection' as used by other systems.
