### PR TITLE
PineconeDB: Delete all existing vectors on index init

### DIFF
--- a/vsb/databases/pinecone/pinecone.py
+++ b/vsb/databases/pinecone/pinecone.py
@@ -1,3 +1,4 @@
+from pinecone import PineconeException
 from pinecone.grpc import PineconeGRPC, GRPCIndex
 
 from ..base import DB, Namespace
@@ -37,6 +38,13 @@ class PineconeDB(DB):
             raise ValueError(
                 f"PineconeDB index '{index_name}' has incorrect metric - expected:{metric.value}, found:{index_metric}"
             )
+        try:
+            self.index.delete(delete_all=True)
+        except PineconeException as e:
+            # Serverless indexes can throw a "Namespace not found" exception for
+            # delete_all if there are no documents in the index. Simply ignore,
+            # as the post-condition is the same.
+            pass
 
     def get_namespace(self, namespace: str) -> Namespace:
         return PineconeNamespace(self.index, namespace)


### PR DESCRIPTION
By default delete all existing vectors before we run the workload, to
ensure we are starting with a clean consistent state.

