### PR TITLE
Remove unused python-dotenv from pyproject.toml deps

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1821,20 +1821,6 @@ files = [
 six = ">=1.5"
 
 [[package]]
-name = "python-dotenv"
-version = "1.0.1"
-description = "Read key-value pairs from a .env file and set them as environment variables"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca"},
-    {file = "python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"},
-]
-
-[package.extras]
-cli = ["click (>=5.0)"]
-
-[[package]]
 name = "pytz"
 version = "2024.1"
 description = "World timezone definitions, modern and historical"
@@ -2284,4 +2270,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "1f465592569db6cd068cf66542678826447f89529d6b591e139f20c37740666a"
+content-hash = "a691fb4f818307561abb5dea89687c60f74bb1648a230ca5f392d6dd0008c66b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ locust = "^2.26.0"
 pandas = "^2.2.1"
 google-cloud-storage = "^2.14.0"
 grpcio = "^1.62.0"
-python-dotenv = "^1.0.1"
 pyarrow = "^15.0.0"
 pinecone-client = {version = "^4.0", extras = ["grpc"]}
 tabulate = "^0.9.0"


### PR DESCRIPTION
Remove unused python-dotenv from pyproject.toml deps
