### PR TITLE
Add 10min timeout to python-package workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,6 +19,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The job currently takes ~2mins, add a timeout to catch (and abort) any
runs which hang.
