### PR TITLE
Pinecone: wait for all vectors to be indexed before completing populate

### DIFF
--- a/vsb/databases/base.py
+++ b/vsb/databases/base.py
@@ -41,4 +41,19 @@ class DB(ABC):
 
     @abstractmethod
     def get_namespace(self, namespace_name: str) -> Namespace:
+        """
+        Returns the Namespace to use for the specified namespace name.
+        """
+        raise NotImplementedError
+
+    def finalize_population(self, record_count: int):
+        """
+        Performs any finalization of the database at the end of the Populate
+        phase. Call should block until the database is ready to perform the
+        next phase.
+        For databases which index records asynchronously, this should wait for all
+        records to be indexed.
+        For databases which perform indexing as a separate step to data ingest,
+        this should create the index(es).
+        """
         raise NotImplementedError

--- a/vsb/workloads/base.py
+++ b/vsb/workloads/base.py
@@ -39,6 +39,15 @@ class VectorWorkload(ABC):
         """
         raise NotImplementedError
 
+    @property
+    @abstractmethod
+    def record_count(self) -> int:
+        """
+        The number of records in the initial workload after population, but
+        before issuing any additional requests.
+        """
+        raise NotImplementedError
+
     @abstractmethod
     def get_record_batch_iter(
         self, num_users: int, user_id: int

--- a/vsb/workloads/mnist/mnist.py
+++ b/vsb/workloads/mnist/mnist.py
@@ -18,6 +18,10 @@ class Mnist(MnistBase):
     def __init__(self, name: str, cache_dir: str):
         super().__init__(name, "mnist", cache_dir=cache_dir)
 
+    @property
+    def record_count(self) -> int:
+        return 60000
+
 
 class MnistTest(MnistBase):
     """Reduced, "test" variant of mnist; with 1% of the full dataset (600
@@ -25,3 +29,7 @@ class MnistTest(MnistBase):
 
     def __init__(self, name: str, cache_dir: str):
         super().__init__(name, "mnist", cache_dir=cache_dir, limit=600, query_limit=20)
+
+    @property
+    def record_count(self) -> int:
+        return 600

--- a/vsb/workloads/nq_768_tasb/nq_768_tasb.py
+++ b/vsb/workloads/nq_768_tasb/nq_768_tasb.py
@@ -18,6 +18,10 @@ class Nq768Tasb(Nq768TasbBase):
     def __init__(self, name: str, cache_dir: str):
         super().__init__(name, "nq-768-tasb", cache_dir=cache_dir)
 
+    @property
+    def record_count(self) -> int:
+        return 2680893
+
 
 class Nq768TasbTest(Nq768TasbBase):
     """Reduced, "test" variant of nq768; with ~1% of the full dataset."""
@@ -26,3 +30,7 @@ class Nq768TasbTest(Nq768TasbBase):
         super().__init__(
             name, "nq-768-tasb", cache_dir=cache_dir, limit=26809, query_limit=35
         )
+
+    @property
+    def record_count(self) -> int:
+        return 26809


### PR DESCRIPTION
## Problem

Pinecone's index building is eventually-consistent - upserted vectors are not immediately indexed and available for querying when Upset() returns.

## Solution

Wait until all records have been indexed before moving to the run phase.

Fixes #54.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

