### PR TITLE
Add --skip_populate option

### DIFF
--- a/vsb/cmdline_args.py
+++ b/vsb/cmdline_args.py
@@ -30,6 +30,12 @@ def add_vsb_cmdline_args(
         default="/tmp/VSB/cache",
         help="Directory to store downloaded datasets",
     )
+    parser.add_argument(
+        "--skip_populate",
+        action="store_true",
+        help="Skip the populate phase (useful if workload has already been loaded and is static)",
+    )
+
     if include_locust_args:
         parser.add_argument(
             "--json",

--- a/vsb/databases/pinecone/pinecone.py
+++ b/vsb/databases/pinecone/pinecone.py
@@ -48,13 +48,15 @@ class PineconeDB(DB):
             raise ValueError(
                 f"PineconeDB index '{index_name}' has incorrect metric - expected:{metric.value}, found:{index_metric}"
             )
-        try:
-            self.index.delete(delete_all=True)
-        except PineconeException as e:
-            # Serverless indexes can throw a "Namespace not found" exception for
-            # delete_all if there are no documents in the index. Simply ignore,
-            # as the post-condition is the same.
-            pass
+        # Start with an empty index if we are going to populate it.
+        if not config["skip_populate"]:
+            try:
+                self.index.delete(delete_all=True)
+            except PineconeException as e:
+                # Serverless indexes can throw a "Namespace not found" exception for
+                # delete_all if there are no documents in the index. Simply ignore,
+                # as the post-condition is the same.
+                pass
 
     def get_namespace(self, namespace: str) -> Namespace:
         return PineconeNamespace(self.index, namespace)

--- a/vsb/users.py
+++ b/vsb/users.py
@@ -191,8 +191,13 @@ class LoadShape(LoadTestShape):
                 self.runner.environment.runner.register_message(
                     "update_progress", self.on_update_progress
                 )
-                self.num_users = self.runner.environment.parsed_options.num_users
-                self.phase = LoadShape.Phase.Populate
+                parsed_opts = self.runner.environment.parsed_options
+                self.num_users = parsed_opts.num_users
+                self.phase = (
+                    LoadShape.Phase.Run
+                    if parsed_opts.skip_populate
+                    else LoadShape.Phase.Populate
+                )
                 return self.tick()
             case LoadShape.Phase.Populate:
                 return self.num_users, self.num_users, [PopulateUser]


### PR DESCRIPTION
If specified, then skip the populate phase and perform the run phase directly.
