### PR TITLE
Add YFCC (filtered) workload

### DIFF
--- a/tests/integration/test_pinecone.py
+++ b/tests/integration/test_pinecone.py
@@ -237,3 +237,21 @@ class TestPinecone:
                 "Search": {"num_requests": 20, "num_failures": 0},
             },
         )
+
+    def test_filtered(self, api_key, pinecone_index_yfcc):
+        # Tests a workload with metadata and filtering (such as YFCC-test).
+        (proc, stdout, stderr) = spawn_vsb(
+            workload="yfcc-test",
+            api_key=api_key,
+            index_name=pinecone_index_yfcc,
+            extra_args=["--users=10"],
+        )
+        assert proc.returncode == 0
+        check_request_counts(
+            stdout,
+            {
+                # Populate num_requests counts batches, not individual records.
+                "Populate": {"num_requests": 10_000 / 200, "num_failures": 0},
+                "Search": {"num_requests": 500, "num_failures": 0},
+            },
+        )

--- a/vsb/users.py
+++ b/vsb/users.py
@@ -7,6 +7,8 @@ from locust import User, task, LoadTestShape
 from locust.exception import StopUser
 
 from vsb.databases import DB
+from vsb.vsb_types import RecordList, SearchRequest
+from vsb.workloads import VectorWorkload
 
 # Dict of Distributors - objects which distribute test data across all
 # VSB Users, potentially across multiple processes.
@@ -33,7 +35,7 @@ class PopulateUser(User):
         logging.debug(f"Initialising PopulateUser id:{self.user_id}")
         self.users_total = environment.parsed_options.num_users
         self.database: DB = environment.database
-        self.workload = environment.workload
+        self.workload: VectorWorkload = environment.workload
         self.state = PopulateUser.State.Active
         self.load_iter = None
 
@@ -56,6 +58,7 @@ class PopulateUser(User):
                     num_users=self.users_total, user_id=self.user_id
                 )
             try:
+                vectors: RecordList
                 (tenant, vectors) = next(self.load_iter)
                 index = self.database.get_namespace(tenant)
 

--- a/vsb/vsb_types.py
+++ b/vsb/vsb_types.py
@@ -1,18 +1,32 @@
 from enum import Enum
 
-from pydantic import BaseModel
+from pydantic import BaseModel, RootModel
 
-Vector = list[float]
+VectorInt = list[int]
+VectorFloat = list[float]
+Vector = VectorInt | VectorFloat
 
 
 class Record(BaseModel):
     id: str
     values: Vector
+    metadata: dict = None
+
+
+class RecordList(RootModel):
+    root: list[Record]
+
+    def __iter__(self):
+        return iter(self.root)
+
+    def __getitem__(self, item):
+        return self.root[item]
 
 
 class SearchRequest(BaseModel):
     values: Vector
     top_k: int
+    filter: dict = None
 
 
 class DistanceMetric(Enum):

--- a/vsb/workloads/__init__.py
+++ b/vsb/workloads/__init__.py
@@ -12,6 +12,8 @@ class Workload(Enum):
     MnistTest = "mnist-test"
     Nq768 = "nq768"
     Nq768Test = "nq768-test"
+    YFCC = "yfcc-10M"
+    YFCCTest = "yfcc-test"
 
     def build(self, **kwargs) -> VectorWorkload:
         """Construct an instance of VectorWorkload based on the value of the enum."""
@@ -37,3 +39,11 @@ class Workload(Enum):
                 from .nq_768_tasb.nq_768_tasb import Nq768TasbTest
 
                 return Nq768TasbTest
+            case Workload.YFCC:
+                from .yfcc.yfcc import YFCC
+
+                return YFCC
+            case Workload.YFCCTest:
+                from .yfcc.yfcc import YFCCTest
+
+                return YFCCTest

--- a/vsb/workloads/base.py
+++ b/vsb/workloads/base.py
@@ -1,17 +1,7 @@
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
 
-from vsb.vsb_types import Record, SearchRequest, DistanceMetric
-
-
-class RecordBatchIterator:
-    """
-    An iterator over a sequence of Records from a Vector Workload. Yields
-    batches of records of a requested count.
-    Used for initial data ingest; a RecordBatchIterator supports iterating over
-    a subset of Records if multiple users are ingesting data concurrently -
-    e.g. for a complete Workload of 1,000 Records and 2 users, each instance of
-    RecordBatchIterator (suitably initialised) will yield 500 records each.
-    """
+from vsb.vsb_types import SearchRequest, DistanceMetric, RecordList
 
 
 class VectorWorkload(ABC):
@@ -51,13 +41,13 @@ class VectorWorkload(ABC):
     @abstractmethod
     def get_record_batch_iter(
         self, num_users: int, user_id: int
-    ) -> RecordBatchIterator:
+    ) -> Iterator[tuple[str, RecordList]]:
         """
         For initial record ingest, returns a RecordBatchIterator over the
         records for the specified `user_id`, assuming there is a total of
         `num_users` which will be ingesting data - i.e. for the entire workload
         to be loaded there should be `num_users` calls to this method.
-        Returns an RecordBatchIterator which yields a tuple of
+        Returns an Iterator which yields a tuple of
         (namespace, batch of records), or (None, None) if there are no more
         records to load.
         :param num_users: The number of clients the dataset ingest is

--- a/vsb/workloads/yfcc/yfcc.py
+++ b/vsb/workloads/yfcc/yfcc.py
@@ -1,0 +1,43 @@
+from abc import ABC
+
+from ..parquet_workload.parquet_workload import ParquetWorkload
+from ...vsb_types import DistanceMetric
+
+
+class YFCCBase(ParquetWorkload, ABC):
+    @property
+    def dimensions(self) -> int:
+        return 192
+
+    @property
+    def metric(self) -> DistanceMetric:
+        return DistanceMetric.Euclidean
+
+
+class YFCC(YFCCBase):
+    def __init__(self, name: str, cache_dir: str):
+        super().__init__(
+            name, "yfcc-10M-filter-euclidean-formatted", cache_dir=cache_dir
+        )
+
+    @property
+    def record_count(self) -> int:
+        return 10_000_000
+
+
+class YFCCTest(YFCCBase):
+    """Reduced, "test" variant of YFCC; with ~0.1% of the full dataset / 0.5%
+    of queries"""
+
+    def __init__(self, name: str, cache_dir: str):
+        super().__init__(
+            name,
+            "yfcc-100K-filter-euclidean-formatted",
+            limit=10_000,
+            query_limit=500,
+            cache_dir=cache_dir,
+        )
+
+    @property
+    def record_count(self) -> int:
+        return 10_000


### PR DESCRIPTION
## Solution

Add workloads 'yfcc-10M' and yfcc-test (100k documents) from
https://big-ann-benchmarks.com/neurips23.html 'Filtered Search'
workload.

This dataset includes metadata (bag of integer tags) on each record,
and metadata filtering as part of the query set, so we need to expand
the Parquet file loader to read metadata column and include in upsert;
then read the filter and include in the search requests.

Additionally YFCC has uint8_t embeddings, so we need to support
integer or float types of vector.

- **get_batch_iterator(): don't attempt to load an empty list**
- **LoadShape.on_update_progress: Reduce log verbosity**
- **Add YFCC Parquet workload (filtered)**

Fixes #7.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

New test using YFCC added.
