### PR TITLE
Users: Avoid multiple PopulateUsers from clearing index

### DIFF
--- a/tests/integration/test_pinecone.py
+++ b/tests/integration/test_pinecone.py
@@ -186,7 +186,7 @@ class TestPinecone:
             workload="mnist-test",
             api_key=api_key,
             index_name=pinecone_index_mnist,
-            extra_args=["--processes=2", "--users=4"],
+            extra_args=["--processes=4", "--users=4"],
         )
         assert proc.returncode == 0
 
@@ -199,8 +199,8 @@ class TestPinecone:
                 # number of requests will be equal to the number of users - i.e. 4
                 "Populate": {"num_requests": 4, "num_failures": 0},
                 # TODO: We should only issue each search query once, but currently
-                # we perform the query once per process (2)
-                "Search": {"num_requests": 20 * 2, "num_failures": 0},
+                # we perform the query once per process (4)
+                "Search": {"num_requests": 20 * 4, "num_failures": 0},
             },
         )
 

--- a/vsb/databases/base.py
+++ b/vsb/databases/base.py
@@ -52,6 +52,18 @@ class DB(ABC):
         """
         raise NotImplementedError
 
+    def initialize_population(self):
+        """
+        Performs any initialization of the database at the beginning of the
+        Populate phase - i.e. before Namespace.upsert_batch() is called.
+        Note this is only called once per test run, irrespective of how many
+        users have been configured (not per user).
+        This could include creating any initial datastructures on the database,
+        or one-time configuration. For implementations which don't need
+        any initialization before data is populated, this method left as empty.
+        """
+        pass
+
     def finalize_population(self, record_count: int):
         """
         Performs any finalization of the database at the end of the Populate

--- a/vsb/locustfile.py
+++ b/vsb/locustfile.py
@@ -24,7 +24,7 @@ import locust.stats
 # Note: These are _not_ unused, they are required to register our User
 # and custom LoadShape classes with locust.
 import users
-from users import PopulateUser, RunUser, LoadShape
+from users import SetupUser, PopulateUser, RunUser, LoadShape
 
 # Display stats of benchmark so far to console very 5 seconds.
 locust.stats.CONSOLE_STATS_INTERVAL_SEC = 5
@@ -46,18 +46,14 @@ def on_locust_init(environment, **_kwargs):
     num_users = options.num_users or 1
     options.spawn_rate = num_users
 
-    # Create a Distributor which assigns monotonically user_ids to each
-    # VectorSearchUser, so we can split the workload between them.
-    users.distributors["user_id.populate"] = Distributor(
-        environment,
-        iter(range(num_users)),
-        "user_id.populate",
-    )
-    users.distributors["user_id.run"] = Distributor(
-        environment,
-        iter(range(num_users)),
-        "user_id.run",
-    )
+    # Create Distributors which assigns monotonically user_ids to each
+    # of the different USer phasesUser, so we can split the workload between
+    # them.
+    phases = ["setup", "populate", "run"]
+    for phase in ["user_id." + p for p in phases]:
+        users.distributors[phase] = Distributor(
+            environment, iter(range(num_users)), phase
+        )
 
 
 def setup_runner(env):


### PR DESCRIPTION
## Problem

Currently any existing index is cleared at the start of the Populate
phase (when the DB subclass' __init__ method is called). This is fine
if there is just a single user specified (--users=1), however if there
are multiple users (particulary running on multiple processes) then we
will clear the index multiple times, which may result in losing
records if the one PopulateUser starts upserting records before other
PopulateUser instance(s) have cleared the index.

## Solution

Address this by introducing a new Setup phase and corresponding
SetupUser. This new phase will only call the index setup code on a
single task instance, waiting for it to complete before advancing to
the PopulatePhase (with multiple users).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Increased concurrency of multiprocess test to expose this issue more readily.
