### PR TITLE
Validate conditionally-required arguments at startup

### DIFF
--- a/vsb.py
+++ b/vsb.py
@@ -4,7 +4,7 @@ import sys
 import configargparse
 import locust.main
 
-from vsb.cmdline_args import add_vsb_cmdline_args
+from vsb.cmdline_args import add_vsb_cmdline_args, validate_parsed_args
 
 
 def main():
@@ -20,13 +20,17 @@ def main():
     # inside vsb/locustfile.py which calls the same add_cmdline_ags() method
     # as below.
     parser = configargparse.ArgumentParser(
-        prog="VCB", description="Vector Search Bench"
+        prog="vsb.py",
+        description="Vector Search Bench",
+        usage="vsb.py --database=<DATABASE> --workload=<WORKLOAD> [additional "
+        "options...]\nPass --help for full list of options.\n",
     )
     add_vsb_cmdline_args(parser, include_locust_args=True)
 
-    # Parse options here validate arguments passed, and to print the vsb usage
+    # Parse options and validate arguments passed, and to print the vsb usage
     # message (and exit) if args fail validation or --help passed.
-    parser.parse_args()
+    args = parser.parse_args()
+    validate_parsed_args(parser, args)
 
     # If we got here then args are valid - pass them on to locusts' main(),
     # appending the location of our locustfile and --headless to start


### PR DESCRIPTION
## Problem

Different databases require different arguments - for example:

    pinecone requires that --pinecone_api_key and --pinecone_index_name are specified.

Currently this is not validated as part of parsing the command-line
options, and will only be detected later on when we attempt to
initialise the given database, which isn't necessarily clear to the
user.

## Solution

Improve this by adding explicit checking that such
conditionally-required arguments are indeed specified, printing out a
relevent error message if any are omitted.

Fixes #77.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Added test which verifies we check for the optional args correctly.
