### PR TITLE
Pinecone: add retry support for search requests

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2251,6 +2251,21 @@ files = [
 widechars = ["wcwidth"]
 
 [[package]]
+name = "tenacity"
+version = "8.3.0"
+description = "Retry code until it succeeds"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "tenacity-8.3.0-py3-none-any.whl", hash = "sha256:3649f6443dbc0d9b01b9d8020a9c4ec7a1ff5f6f3c6c8a036ef371f573fe9185"},
+    {file = "tenacity-8.3.0.tar.gz", hash = "sha256:953d4e6ad24357bceffbc9707bc74349aca9d245f68eb65419cf0c249a1949a2"},
+]
+
+[package.extras]
+doc = ["reno", "sphinx"]
+test = ["pytest", "tornado (>=4.5)", "typeguard"]
+
+[[package]]
 name = "tqdm"
 version = "4.66.4"
 description = "Fast, Extensible Progress Meter"
@@ -2420,4 +2435,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "1798fcbe825e3b3edc83161c414c3aadc09260bbcef83f648225f65a52fe036f"
+content-hash = "2f67a460af48270345ee70b07219ea46c31e607a2a2ee0e8bb02a2af1b838560"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ locust-plugins = "^4.4.3"
 pgvector = "^0.2.5"
 psycopg = "^3.1.19"
 hdrhistogram = "^0.10.3"
+tenacity = "^8.3.0"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## Problem

Pinecone search requests (implemented with query()) can somtimes fail transiently - the most common reason is a serverless index which has hit the RU rate limit.

## Solution

Add support for automatically retrying such failures using tenacity.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

Difficult to test automatically without an in error-injection framework. Tested manually against a serverless index and a large (20) number of concurrent users.
