### PR TITLE
tests: Move common functions to conftest.py

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,122 @@
+import json
+import os
+import random
+import string
+import subprocess
+import sys
+from subprocess import PIPE
+
+
+def read_env_var(name):
+    value = os.environ.get(name)
+    if value is None:
+        raise Exception(f"Environment variable {name} is not set")
+    return value
+
+
+def random_string(length):
+    return "".join(random.choice(string.ascii_lowercase) for _ in range(length))
+
+
+def parse_stats_to_json(stdout: str) -> list(dict()):
+    """
+    Parse stdout from VSB into a list of JSON dictionaries, one for each
+    worker which reported stats.
+    """
+    # For each task type (Populate, Search, ...) we see a JSON object,
+    # so must handle multiple JSON objects in stdout.
+    stats = []
+    while stdout:
+        try:
+            stats += json.loads(stdout)
+            break
+        except json.JSONDecodeError as e:
+            stdout = stdout[e.pos :]
+    return stats
+
+
+def check_request_counts(stdout, expected: dict()) -> None:
+    """Given stdout in JSON format from vsb and a dict of expected elements
+    to find in stdout, check all expected fields are present, asserting on
+    any mismatches.
+
+    Elements of expected should be nested dicts where their top-level keys
+    are request_type names (Populate, Search, ...) and the values are dicts
+    of expected elements to find for each request type - e.g.
+
+        {
+            "Search": {
+                 "num_requests": 20,
+                 "num_failures": 0,
+            },
+        }
+
+    The values of the leaf elements can either be literals (e.g. '20' for
+    "num_requests" above) or callables, if more complex checks are needed -
+    for example to check that "recall" is a list of 20 elements (but not
+    checking what the individual values are):
+
+        {
+            "Search": { "recall": lambda x: len(x) == 20, }
+        }
+    """
+    stats = parse_stats_to_json(stdout)
+    by_method = {s["method"]: s for s in stats}
+    for phase, expected_stats in expected.items():
+        assert phase in by_method, f"Missing stats for expected phase '{phase}'"
+        for ex_name, ex_value in expected_stats.items():
+            actual_value = by_method[phase][ex_name]
+            if callable(ex_value):
+                assert ex_value(actual_value), (
+                    f"For phase {phase} and " f"stat {ex_name}"
+                )
+            else:
+                assert actual_value == ex_value, (
+                    f"For phase {phase} and " f"stat {ex_name}"
+                )
+
+
+def spawn_vsb_inner(
+    database,
+    workload,
+    timeout=60,
+    extra_args: list = None,
+    extra_env: dict = None,
+):
+    """Inner function to spawn an instance of vsb with the given arguments,
+    returning the proc object, its stdout and stderr.
+    Allows api_key and index_name to be omitted, to test how vsb handles that.
+    """
+    if extra_args is None:
+        extra_args = []
+    env = os.environ.copy()
+    if extra_env:
+        env.update(extra_env)
+    args = [
+        "./vsb.py",
+        f"--database={database}",
+        f"--workload={workload}",
+        "--json",
+        "--loglevel=DEBUG",
+    ]
+    proc = subprocess.Popen(
+        args + extra_args,
+        stdout=PIPE,
+        stderr=PIPE,
+        env=env,
+        text=True,
+    )
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired as e:
+        # kill process and capture as much stdout / stderr as we can.
+        proc.kill()
+        stdout, stderr = proc.communicate()
+        print(stdout)
+        print(stderr, file=sys.stderr)
+        raise
+    # Echo subprocesses stdout & stderr to our own, so pytest can capture and
+    # report them on error.
+    print(stdout)
+    print(stderr, file=sys.stderr)
+    return proc, stdout, stderr

--- a/tests/integration/test_pinecone.py
+++ b/tests/integration/test_pinecone.py
@@ -1,25 +1,10 @@
 import datetime
-import json
 import os
-import random
-import string
-import sys
-import subprocess
-from subprocess import PIPE
 
 import pytest
 from pinecone import Pinecone
 
-
-def read_env_var(name):
-    value = os.environ.get(name)
-    if value is None:
-        raise Exception(f"Environment variable {name} is not set")
-    return value
-
-
-def random_string(length):
-    return "".join(random.choice(string.ascii_lowercase) for _ in range(length))
+from conftest import check_request_counts, read_env_var, random_string, spawn_vsb_inner
 
 
 @pytest.fixture
@@ -72,91 +57,19 @@ def pinecone_index_yfcc():
     _delete_pinecone_index(index_name)
 
 
-def spawn_vsb(workload, api_key, index_name, timeout=60, extra_args=None):
+def spawn_vsb(workload, api_key=None, index_name=None, timeout=60, extra_args=None):
     """Spawn an instance of vsb with the given arguments, returning the proc object,
     its stdout and stderr.
     """
-    return spawn_vsb_inner(workload, api_key, index_name, timeout, extra_args)
-
-
-def spawn_vsb_inner(
-    workload, api_key=None, index_name=None, timeout=60, extra_args=None
-):
-    """Inner function to spawn an instance of vsb with the given arguments,
-    returning the proc object, its stdout and stderr.
-    Allows api_key and index_name to be omitted, to test how vsb handles that.
-    """
-    if extra_args is None:
-        extra_args = []
-    env = os.environ.copy()
-    if api_key is not None:
-        env.update({"VSB__PINECONE_API_KEY": api_key})
-    args = [
-        "./vsb.py",
-        "--database",
-        "pinecone",
-        "--workload",
-        workload,
-        "--json",
-        "--loglevel=DEBUG",
-    ]
+    args = []
     if index_name:
         args += ["--pinecone_index_name", index_name]
-    proc = subprocess.Popen(
-        args + extra_args,
-        stdout=PIPE,
-        stderr=PIPE,
-        env=env,
-        text=True,
-    )
-    try:
-        stdout, stderr = proc.communicate(timeout=timeout)
-    except subprocess.TimeoutExpired as e:
-        # kill process and capture as much stdout / stderr as we can.
-        proc.kill()
-        stdout, stderr = proc.communicate()
-        print(stdout)
-        print(stderr, file=sys.stderr)
-        raise
-    # Echo subprocesses stdout & stderr to our own, so pytest can capture and
-    # report them on error.
-    print(stdout)
-    print(stderr, file=sys.stderr)
-    return proc, stdout, stderr
-
-
-def parse_stats_to_json(stdout: str) -> list(dict()):
-    """
-    Parse stdout from VSB into a list of JSON dictionaries, one for each
-    worker which reported stats.
-    """
-    # For each task type (Populate, Search, ...) we see a JSON object,
-    # so must handle multiple JSON objects in stdout.
-    stats = []
-    while stdout:
-        try:
-            stats += json.loads(stdout)
-            break
-        except json.JSONDecodeError as e:
-            stdout = stdout[e.pos :]
-    return stats
-
-
-def check_request_counts(stdout, expected: dict()):
-    stats = parse_stats_to_json(stdout)
-    by_method = {s["method"]: s for s in stats}
-    for phase, expected_stats in expected.items():
-        assert phase in by_method, f"Missing stats for expected phase '{phase}'"
-        for ex_name, ex_value in expected_stats.items():
-            actual_value = by_method[phase][ex_name]
-            if callable(ex_value):
-                assert ex_value(actual_value), (
-                    f"For phase {phase} and " f"stat {ex_name}"
-                )
-            else:
-                assert actual_value == ex_value, (
-                    f"For phase {phase} and " f"stat {ex_name}"
-                )
+    if extra_args:
+        args += extra_args
+    extra_env = {}
+    if api_key:
+        extra_env.update({"VSB__PINECONE_API_KEY": api_key})
+    return spawn_vsb_inner("pinecone", workload, timeout, args, extra_env)
 
 
 class TestPinecone:
@@ -199,7 +112,11 @@ class TestPinecone:
                 # chunk will be less than the batch size (600 / 4 < 200), then the
                 # number of requests will be equal to the number of users - i.e. 4
                 "Populate": {"num_requests": 4, "num_failures": 0},
-                "Search": {"num_requests": 20, "num_failures": 0},
+                "Search": {
+                    "num_requests": 20,
+                    "num_failures": 0,
+                    "recall": lambda x: len(x) == 20,
+                },
             },
         )
 
@@ -224,7 +141,11 @@ class TestPinecone:
                 "Populate": {"num_requests": 4, "num_failures": 0},
                 # TODO: We should only issue each search query once, but currently
                 # we perform the query once per process (4)
-                "Search": {"num_requests": 20 * 4, "num_failures": 0},
+                "Search": {
+                    "num_requests": 20 * 4,
+                    "num_failures": 0,
+                    "recall": lambda x: len(x) == 20 * 4,
+                },
             },
         )
 
@@ -241,7 +162,11 @@ class TestPinecone:
             {
                 # Populate num_requests counts batches, not individual records.
                 "Populate": {"num_requests": 2, "num_failures": 0},
-                "Search": {"num_requests": 20, "num_failures": 0},
+                "Search": {
+                    "num_requests": 20,
+                    "num_failures": 0,
+                    "recall": lambda x: len(x) == 20,
+                },
             },
         )
 
@@ -257,7 +182,11 @@ class TestPinecone:
             stdout,
             {
                 # Populate num_requests counts batches, not individual records.
-                "Search": {"num_requests": 20, "num_failures": 0},
+                "Search": {
+                    "num_requests": 20,
+                    "num_failures": 0,
+                    "recall": lambda x: len(x) == 20,
+                },
             },
         )
 
@@ -281,7 +210,7 @@ class TestPinecone:
 
     def test_required_args(self, api_key, pinecone_index_mnist):
         # Tests that all required args are correctly checked for at vsb startup.
-        (proc, stdout, stderr) = spawn_vsb_inner(api_key=api_key, workload="mnist-test")
+        (proc, stdout, stderr) = spawn_vsb(api_key=api_key, workload="mnist-test")
         assert proc.returncode == 2
         assert (
             "The following arguments must be specified when --database is "
@@ -289,7 +218,7 @@ class TestPinecone:
         ) in stderr
         assert "--pinecone_index_name" in stderr
 
-        (proc, stdout, stderr) = spawn_vsb_inner(
+        (proc, stdout, stderr) = spawn_vsb(
             index_name=pinecone_index_mnist, workload="mnist-test"
         )
         assert proc.returncode == 2


### PR DESCRIPTION
Move common integration test functions to conftest.py, and expand the metrics checks for recall to the pgvector tests.
