### PR TITLE
Calculate percentiles for reported metrics (Recall)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -965,6 +965,84 @@ files = [
 protobuf = ["grpcio-tools (>=1.64.1)"]
 
 [[package]]
+name = "hdrhistogram"
+version = "0.10.3"
+description = "High Dynamic Range histogram in native python"
+optional = false
+python-versions = "*"
+files = [
+    {file = "hdrhistogram-0.10.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5ca99b4ea5c4a94fff9ed9e76fe308273376f630c461379671fcbdd2c9934b0b"},
+    {file = "hdrhistogram-0.10.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a52d892b093e7906c91d577dafe75c2d8864a8e113e98d6f88848f9ce40a952f"},
+    {file = "hdrhistogram-0.10.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b12d915dab421f269a50e3831510f11fece8268c4a4543b5a2dca21fcdfb6aa"},
+    {file = "hdrhistogram-0.10.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:b58256f9f8a47aee37b1fec6a3f069212b6174162f7cd814e1dcd3afbef389b2"},
+    {file = "hdrhistogram-0.10.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:38f1b5c45e71e2a3b982fb1b25c17ad9eaed2f0b014ea6637373630b18644945"},
+    {file = "hdrhistogram-0.10.3-cp310-cp310-win32.whl", hash = "sha256:19c5fff0cdf22a12fe68d3e09f928c0fc7873adb235f98a214222fb7b2249a3e"},
+    {file = "hdrhistogram-0.10.3-cp310-cp310-win_amd64.whl", hash = "sha256:bbe025f00445c842440c5c1cf3b7665a1a37e7d954142bcbf0838a7bb307b9ef"},
+    {file = "hdrhistogram-0.10.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d5748a22ec68a5390f9d493aca933a6871788e34df91da4cc0a6ee19e336dc6d"},
+    {file = "hdrhistogram-0.10.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f6d7e402365ced65309c3ffb060b6bcf7d1265bfba293509076f18b5d9ec260d"},
+    {file = "hdrhistogram-0.10.3-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f55fcbd39953b8989344cfb56cfa06094dbffc3fd4df1ff05d4b15658e1bf6d"},
+    {file = "hdrhistogram-0.10.3-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:d814811d52e699426a8b54f2448ab5e49fee3519a200cd887fd3faaaa6f4a35d"},
+    {file = "hdrhistogram-0.10.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:bfd6ad77c1f7806aaeb6b340866a6bb38a1f0fe94d8f5a5f74372c33a094913f"},
+    {file = "hdrhistogram-0.10.3-cp311-cp311-win32.whl", hash = "sha256:28950b3ffaa97e859f76a08932a6c2a5baeca2a140804e0fd03b3b1d622a6c92"},
+    {file = "hdrhistogram-0.10.3-cp311-cp311-win_amd64.whl", hash = "sha256:e07dc9d667c71b061cc56a721f0005d8d77cf1a7f383902657703ac3ecd026f6"},
+    {file = "hdrhistogram-0.10.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:088d3ef64c2004fc3cd4b21c4292efe4648367a1ce98c554bf7c5730a0ba018e"},
+    {file = "hdrhistogram-0.10.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bda8ae7ab424e6f2221ae9daed20610becb5d59cae2d448a05077b00e864c9e7"},
+    {file = "hdrhistogram-0.10.3-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2ba2550e8a392a543e727a4875f76f7131d1dd04ebe7c03d3cbe44b83fc130b"},
+    {file = "hdrhistogram-0.10.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:57d61fd8378212d3d24149a331f770278766db541373d20a12f9399788ffde82"},
+    {file = "hdrhistogram-0.10.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ad6d3ca8bcec581b8cf936608f79f6dd619e2690d1135c1978d80b01318e19e3"},
+    {file = "hdrhistogram-0.10.3-cp312-cp312-win32.whl", hash = "sha256:90bf599703cd146b430fd4c111fb1290da902746ddea9c591c1cfb8313d37974"},
+    {file = "hdrhistogram-0.10.3-cp312-cp312-win_amd64.whl", hash = "sha256:92f0a43d0918ee6c48c78097c6e51eced260d0ae459c00a8a3690fbd9a06dc78"},
+    {file = "hdrhistogram-0.10.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:eb9a45365b4a52f16b1e53a3f431ee9ef65a978b5a62ede2be6e2654f43f338b"},
+    {file = "hdrhistogram-0.10.3-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:93eb769a67b27017926208a63914126cef684284a51a8c30126e83bf4cbc273c"},
+    {file = "hdrhistogram-0.10.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:058bcdd518d16d3ccb15d67e5f3dd6a3c9ab79970f474ecd5fa60d4dfa482e53"},
+    {file = "hdrhistogram-0.10.3-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:f8d9d56aedd87aa2347188f5a3b24aaafeee154a92b1741e97a18f2135a18f5a"},
+    {file = "hdrhistogram-0.10.3-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:da0b21803a80fbc395823b873825d188a587fb831ac32733f5bb1d1a67fca134"},
+    {file = "hdrhistogram-0.10.3-cp36-cp36m-win32.whl", hash = "sha256:1f0ebec7b1aa970b4580623444711fa76f7c9f3ed2b702807a1dcbb513d8f50f"},
+    {file = "hdrhistogram-0.10.3-cp36-cp36m-win_amd64.whl", hash = "sha256:1c93c0a00e824e298671f8942e2ffe8cd9a7083800594bebab2110ea948eb640"},
+    {file = "hdrhistogram-0.10.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c6714255d09e8618c5f335ea91fd945e4fcd7f165ac3e71a01354d0225e2cd8d"},
+    {file = "hdrhistogram-0.10.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eedbb4940596404097057382a110160a0a861e926c11d22db2479ab1fdcacd26"},
+    {file = "hdrhistogram-0.10.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f451c9d883abfdf73058b0863d43e4ee577504bd27bd46d257e354a3f21f22c"},
+    {file = "hdrhistogram-0.10.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:3ae3e69a5570812d76ddf647c75a61a321e351819768d8bdd36538ae912eafc1"},
+    {file = "hdrhistogram-0.10.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:63739f63aa5e8fb57df66f020e438d52baa80af42809672a8cb5d655f489afc8"},
+    {file = "hdrhistogram-0.10.3-cp37-cp37m-win32.whl", hash = "sha256:be1cc268d6cfcd7193d87310deb2b4bbf56f58dc5a84382c73c02f4058c0a743"},
+    {file = "hdrhistogram-0.10.3-cp37-cp37m-win_amd64.whl", hash = "sha256:24f6a42d31ece8beaf75d53480be6c6a0ce27e98440f3de1605229b360ef30b9"},
+    {file = "hdrhistogram-0.10.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e358a2112f9b687f8665dd0eab45eb61e2c21e607e6a13ba3831b019931720b3"},
+    {file = "hdrhistogram-0.10.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bdb7700f0f409056cf8147d80862fef7a1c6a2a6a410c31370ce6470600e239f"},
+    {file = "hdrhistogram-0.10.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80be7a23c410e1a3c5f81ddfee4eec57788b8de8e0175e9043181dd839937c3e"},
+    {file = "hdrhistogram-0.10.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:ee8db21d1b3a5bb561afb49ed5eded873629a1a77542eb06237af13f7d3dae97"},
+    {file = "hdrhistogram-0.10.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:ba7b1008820e6a705fec9169db99ff45b8e903fe1d15ae8f11d98cb25a327673"},
+    {file = "hdrhistogram-0.10.3-cp38-cp38-win32.whl", hash = "sha256:20699699638297097104e02c55b1d83c02d123dda98ee25af41d56d6131b4daa"},
+    {file = "hdrhistogram-0.10.3-cp38-cp38-win_amd64.whl", hash = "sha256:56083c578657427693e4ea25770925a79e9c961198776f8205d9155d2096a710"},
+    {file = "hdrhistogram-0.10.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:35960a123b9eb175c52f009da4295624b3e195ecc8ea5e8e49fdb58016d4b4ce"},
+    {file = "hdrhistogram-0.10.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9bd5b71e013408068c3ed6151a81d2e9792edff37b3b66d0c30dd7f287a99d2"},
+    {file = "hdrhistogram-0.10.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:93c77a6366a3fea2dc6fc5a8f13c8d2ccbcc4fb34c2f033a2ed574fc5ca07ad5"},
+    {file = "hdrhistogram-0.10.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9e0765858fbd12ea25d1fd9081ff4524b25aa47fd6652d3413343e8a0e930ade"},
+    {file = "hdrhistogram-0.10.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:51f90e682236532c96705e8b05ca9136911c1aa0a460e908738d7b618077cace"},
+    {file = "hdrhistogram-0.10.3-cp39-cp39-win32.whl", hash = "sha256:0f0ecd6a4efcd4b86d460ac21e1a51702135e1378dac168b92521d780e725b90"},
+    {file = "hdrhistogram-0.10.3-cp39-cp39-win_amd64.whl", hash = "sha256:c5adccd90121badb70d1cf4f0f3618b21b86c240c30d8428228187af30e148ed"},
+    {file = "hdrhistogram-0.10.3-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:75c725e3d424456114f5661d248d8d36dcd9378ca4ae9df6dd536fc8c7f974a5"},
+    {file = "hdrhistogram-0.10.3-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:749676fb15caecfd717fa5a2e9026f27c43ed17a127ed32ae15a2f4f4c5619ee"},
+    {file = "hdrhistogram-0.10.3-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:55771195cd438bdc39d4061a27daafb2c2b36d9842f9f54bf3bb1dec8be8c53a"},
+    {file = "hdrhistogram-0.10.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:f9ed261aa8b5467678356b778eab9f3f12a9003ee4b4b2f53783a343f2c4513c"},
+    {file = "hdrhistogram-0.10.3-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:ce096f9d89dfe4ff9708593e0e5cb9e28c8dd9311c65acb2921530a91e3d043e"},
+    {file = "hdrhistogram-0.10.3-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9e76612d311ac233f184063fc55ac5097fc6dc1629dc4e25ebe4f18384d6d8ca"},
+    {file = "hdrhistogram-0.10.3-pp37-pypy37_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e1ca845e86a296d7efc8a3ff175a0dab614b57adb610b7b1aa4a312becf8319f"},
+    {file = "hdrhistogram-0.10.3-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:36e49a657f47cf0c562372ca0e06334461f558ef29ed8a972210f2a879abf669"},
+    {file = "hdrhistogram-0.10.3-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:c6fe0c64b902ce8ae94fef5f38710d2b51452521812191668b27b664878defd8"},
+    {file = "hdrhistogram-0.10.3-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fb56df2189655fc6b83275a2f6206842eeef3b45b633947ca8a63ad7866bf0d1"},
+    {file = "hdrhistogram-0.10.3-pp38-pypy38_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0fbf9db500382a7f19b05708f327b94bea8e17c6a56e7359f9cc532f5afa2662"},
+    {file = "hdrhistogram-0.10.3-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:9f216fe14d696a6d2aad6ead334fd700ce91ab1ddfeb8bbe9f54e784126c1f5d"},
+    {file = "hdrhistogram-0.10.3-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:3fe865a17462a756650fe2539702df65b8a10ddcb5e1da4eec64a39c502c2af7"},
+    {file = "hdrhistogram-0.10.3-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6c1c4b2431a0f539cddf760ac11fb5828faeb0643635548cefea82868f7486eb"},
+    {file = "hdrhistogram-0.10.3-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c79c269b37132e9ba116c405aa6f331d3bfc7545297609af32f09e94fd6430a"},
+    {file = "hdrhistogram-0.10.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:dc9ff7da871d9149abfa386c44f1d02e83b8b5819ea974f55cf5eed27e9d333a"},
+    {file = "hdrhistogram-0.10.3.tar.gz", hash = "sha256:f3890df0a6f3c582a0a8b2a49a568729cb319f1600683e4458cc98b68ca32841"},
+]
+
+[package.dependencies]
+pbr = ">=1.4"
+
+[[package]]
 name = "identify"
 version = "2.5.36"
 description = "File identification library for Python"
@@ -1435,6 +1513,17 @@ python-versions = ">=3.8"
 files = [
     {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
     {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
+]
+
+[[package]]
+name = "pbr"
+version = "6.0.0"
+description = "Python Build Reasonableness"
+optional = false
+python-versions = ">=2.6"
+files = [
+    {file = "pbr-6.0.0-py2.py3-none-any.whl", hash = "sha256:4a7317d5e3b17a3dccb6a8cfe67dab65b20551404c52c8ed41279fa4f0cb4cda"},
+    {file = "pbr-6.0.0.tar.gz", hash = "sha256:d1377122a5a00e2f940ee482999518efe16d745d423a670c27773dfbc3c9a7d9"},
 ]
 
 [[package]]
@@ -2331,4 +2420,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "71cab943145b673822d8faa919d1e9f999ab62eedeed0e0c68d5878bfe496bb3"
+content-hash = "1798fcbe825e3b3edc83161c414c3aadc09260bbcef83f648225f65a52fe036f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ pydantic = "^2.7.3"
 locust-plugins = "^4.4.3"
 pgvector = "^0.2.5"
 psycopg = "^3.1.19"
+hdrhistogram = "^0.10.3"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -35,6 +35,14 @@ def parse_stats_to_json(stdout: str) -> list(dict()):
     return stats
 
 
+def check_recall_stats(actual: dict) -> bool:
+    """Check that the recall stats are present and have the expected structure."""
+    return all(key in actual for key in ["min", "max", "mean", "percentiles"]) and all(
+        str(pct) in actual["percentiles"].keys()
+        for pct in [1, 5, 25, 50, 90, 99, 99.9, 99.99]
+    )
+
+
 def check_request_counts(stdout, expected: dict()) -> None:
     """Given stdout in JSON format from vsb and a dict of expected elements
     to find in stdout, check all expected fields are present, asserting on

--- a/tests/integration/test_pgvector.py
+++ b/tests/integration/test_pgvector.py
@@ -1,5 +1,11 @@
 import datetime
-from conftest import check_request_counts, read_env_var, random_string, spawn_vsb_inner
+from conftest import (
+    check_request_counts,
+    read_env_var,
+    random_string,
+    spawn_vsb_inner,
+    check_recall_stats,
+)
 
 
 def _get_index_name() -> str:
@@ -31,7 +37,7 @@ class TestPgvector:
                 "Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": lambda x: len(x) == 20,
+                    "recall": check_recall_stats,
                 },
             },
         )
@@ -56,7 +62,7 @@ class TestPgvector:
                 "Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": lambda x: len(x) == 20,
+                    "recall": check_recall_stats,
                 },
             },
         )
@@ -83,7 +89,7 @@ class TestPgvector:
                 "Search": {
                     "num_requests": 20 * 2,
                     "num_failures": 0,
-                    "recall": lambda x: len(x) == 20 * 2,
+                    "recall": check_recall_stats,
                 },
             },
         )
@@ -116,7 +122,7 @@ class TestPgvector:
                 "Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": lambda x: len(x) == 20,
+                    "recall": check_recall_stats,
                 },
             },
         )
@@ -136,7 +142,7 @@ class TestPgvector:
                 "Search": {
                     "num_requests": 500,
                     "num_failures": 0,
-                    "recall": lambda x: len(x) == 500,
+                    "recall": check_recall_stats,
                 },
             },
         )
@@ -157,7 +163,7 @@ class TestPgvector:
                 "Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": lambda x: len(x) == 20,
+                    "recall": check_recall_stats,
                 },
             },
         )

--- a/tests/integration/test_pinecone.py
+++ b/tests/integration/test_pinecone.py
@@ -4,7 +4,13 @@ import os
 import pytest
 from pinecone import Pinecone
 
-from conftest import check_request_counts, read_env_var, random_string, spawn_vsb_inner
+from conftest import (
+    check_request_counts,
+    read_env_var,
+    random_string,
+    spawn_vsb_inner,
+    check_recall_stats,
+)
 
 
 @pytest.fixture
@@ -88,7 +94,7 @@ class TestPinecone:
                 "Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": lambda x: len(x) == 20,
+                    "recall": check_recall_stats,
                 },
             },
         )
@@ -115,7 +121,7 @@ class TestPinecone:
                 "Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": lambda x: len(x) == 20,
+                    "recall": check_recall_stats,
                 },
             },
         )
@@ -144,7 +150,7 @@ class TestPinecone:
                 "Search": {
                     "num_requests": 20 * 4,
                     "num_failures": 0,
-                    "recall": lambda x: len(x) == 20 * 4,
+                    "recall": check_recall_stats,
                 },
             },
         )
@@ -165,7 +171,7 @@ class TestPinecone:
                 "Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": lambda x: len(x) == 20,
+                    "recall": check_recall_stats,
                 },
             },
         )
@@ -185,7 +191,7 @@ class TestPinecone:
                 "Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": lambda x: len(x) == 20,
+                    "recall": check_recall_stats,
                 },
             },
         )
@@ -204,7 +210,11 @@ class TestPinecone:
             {
                 # Populate num_requests counts batches, not individual records.
                 "Populate": {"num_requests": 210, "num_failures": 0},
-                "Search": {"num_requests": 500, "num_failures": 0},
+                "Search": {
+                    "num_requests": 500,
+                    "num_failures": 0,
+                    "recall": check_recall_stats,
+                },
             },
         )
 

--- a/vsb/metrics_tracker.py
+++ b/vsb/metrics_tracker.py
@@ -13,13 +13,31 @@ process.
 import json
 import logging
 
+from hdrh.histogram import HdrHistogram
 from locust import events
 from locust.stats import RequestStats
 
 # Calculated custom metrics for each performed operation.
 # Nested dict, where top-level is the request_type (Populate, Search, ...), under
-# that there is a dict keyed on metric name (recall, ...)
-calculated_metrics: dict[str, dict[str, list[float]]] = {}
+# that there is an instance of HdrHistogram for each metric name (
+# recall, ...)
+calculated_metrics: dict[str, dict[str, HdrHistogram]] = {}
+
+# Scale factor for the histograms - we multiply all values by this factor before
+# storing them in the histogram. This is because metrics are typically floats
+# in domain [0.0, 1.0], yet HdrHistogram only deals with integer values so
+# we need to map to the supported range.
+HDR_SCALE_FACTOR = 1000
+
+
+def get_histogram(request_type: str, metric: str) -> HdrHistogram:
+    """
+    Get the histogram for the given metric for the given request type,
+    creating an empty histogram is the request type and/or metric is not already
+    recorded.
+    """
+    req_type_metrics = calculated_metrics.setdefault(request_type, dict())
+    return req_type_metrics.setdefault(metric, HdrHistogram(1, 100_000, 3))
 
 
 def print_stats_json(stats: RequestStats) -> None:
@@ -31,7 +49,18 @@ def print_stats_json(stats: RequestStats) -> None:
     serialized = stats.serialize_stats()
     for s in serialized:
         if custom := calculated_metrics.get(s["method"], None):
-            s.update(custom)
+            for metric, hist in custom.items():
+                info = {
+                    "min": hist.get_min_value() / HDR_SCALE_FACTOR,
+                    "max": hist.get_max_value() / HDR_SCALE_FACTOR,
+                    "mean": hist.get_mean_value() / HDR_SCALE_FACTOR,
+                    "percentiles": {},
+                }
+                for p in [1, 5, 25, 50, 90, 99, 99.9, 99.99]:
+                    info["percentiles"][p] = (
+                        hist.get_value_at_percentile(p) / HDR_SCALE_FACTOR
+                    )
+                s[metric] = info
     print(json.dumps(serialized, indent=4))
 
 
@@ -42,9 +71,8 @@ def on_request(request_type, name, response_time, response_length, **kwargs):
     requests' custom metrics here (from "metrics" kwarg).
     """
     if req_metrics := kwargs.get("metrics", None):
-        req_type_metrics = calculated_metrics.setdefault(request_type, dict())
         for k, v in req_metrics.items():
-            req_type_metrics.setdefault(k, []).append(v)
+            get_histogram(request_type, k).record_value(v * HDR_SCALE_FACTOR)
 
 
 @events.report_to_master.add_listener
@@ -58,7 +86,15 @@ def on_report_to_master(client_id, data: dict()):
     logging.debug(
         f"metrics.on_report_to_master(): calculated_metrics:{calculated_metrics}"
     )
-    data["metrics"] = calculated_metrics.copy()
+    serialized = {}
+    for req_type, metrics in calculated_metrics.items():
+        # Serialise each HdrHistogram to base64 string, then add to data to be sent to
+        # the master instance.
+        serialized[req_type] = {}
+        hist: HdrHistogram
+        for metric, hist in metrics.items():
+            serialized[req_type][metric] = hist.encode()
+    data["metrics"] = serialized
     calculated_metrics.clear()
 
 
@@ -71,6 +107,7 @@ def on_worker_report(client_id, data: dict()):
     """
     logging.debug(f"metrics.on_worker_report(): data:{data}")
     for req_type, metrics in data["metrics"].items():
-        req_type_metrics = calculated_metrics.setdefault(req_type, dict())
-        for k, v in metrics.items():
-            req_type_metrics.setdefault(k, []).extend(v)
+        # Decode the base64 string back to an HdrHistogram, then add to the master's
+        # stats.
+        for metric_name, base64_histo in metrics.items():
+            get_histogram(req_type, metric_name).decode_and_add(base64_histo)


### PR DESCRIPTION
Enhance the recording of custom metrics (currently just Recall) to record them in a histogram, and then report a range of interesting summaries of these stats via the --json output:

* min
* max
* mean
* percentiles: 1, 5, 25, 50, 90, 99, 99.9, 99.99

HdrHistogram_py is used for the histogram handling, as this allows efficient aggregation of histograms (needed for the runner -> master merging), and also supports a wide range of recorded values in a space-efficient format.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Test Plan

Integration tests updated to check for the reported metrics. 