### PR TITLE
GitHub workflows/python-package.yml: Report 10 slowest tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -57,7 +57,7 @@ jobs:
         DOCKER_BUILDKIT: 1
     - name: Test with pytest
       run: |
-        poetry run pytest
+        poetry run pytest --durations=10
       env:
         ENVIRONMENT: ${{ matrix.environment == 'pod' && 'us-east4-gcp' || '' }}
         SERVERLESS_REGION: us-west-2


### PR DESCRIPTION
## Problem

CI is now taking around 3min. While this isn't a vast amount of time,
it's enough that one will context-switch away from an uploaded PR
while waiting for the results.

## Solution

Report the 10 slowest tests to give visibility on which tests are the slowest and where effort should be applied to improve runtime.

## Type of Change

- [x] Infrastructure change (CI configs, etc)
