### PR TITLE
Convert vsb.py to a python package

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To run VSB against a cloud-hosted vector database, simply
 provide suitable credentials to an existing database instance. For example
 to run against a Pinecone index:
 ```shell
-./vsb.py --database=pinecone --workload=mnist-test \
+vsb --database=pinecone --workload=mnist-test \
     --pinecone_api_key=<API_KEY> \
     --pinecone_index_name=<INDEX_NAME>
 ```
@@ -61,7 +61,7 @@ docker compose up
 
 From a second terminal run VSB:
 ```shell
-./vsb.py --database=pgvector --workload=mnist-test
+vsb --database=pgvector --workload=mnist-test
 ```
 
 Example output:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 description = "A vector search benchmarking suite, built on the Locust framework"
 authors = ["Pinecone Systems, Inc. <support@pinecone.io>"]
 readme = "README.md"
-package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.11"
@@ -22,6 +21,8 @@ psycopg = "^3.1.19"
 hdrhistogram = "^0.10.3"
 tenacity = "^8.3.0"
 
+[tool.poetry.scripts]
+vsb = "vsb.main:main"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.4.2"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -101,7 +101,7 @@ def spawn_vsb_inner(
     if extra_env:
         env.update(extra_env)
     args = [
-        "./vsb.py",
+        "vsb",
         f"--database={database}",
         f"--workload={workload}",
         "--json",

--- a/vsb/main.py
+++ b/vsb/main.py
@@ -19,16 +19,16 @@ def main():
     # large number of highly configurable arguments locust provides.
     #
     # As such, we define our own argument parser and parse the user's options
-    # before locust - this ensures that 'vsb.py --help' only shows the relevant
+    # before locust - this ensures that 'vsb --help' only shows the relevant
     # benchmarking arguments. To ensure we can later consume those arguments
     # inside VSB, we _also_ need to add the arguments to locust's own
     # parser, which is done by adding a listener to init_command_line_parser
     # inside vsb/locustfile.py which calls the same add_cmdline_args() method
     # as below.
     parser = configargparse.ArgumentParser(
-        prog="vsb.py",
+        prog="vsb",
         description="Vector Search Bench",
-        usage="vsb.py --database=<DATABASE> --workload=<WORKLOAD> [additional "
+        usage="vsb --database=<DATABASE> --workload=<WORKLOAD> [additional "
         "options...]\nPass --help for full list of options.\n",
     )
     add_vsb_cmdline_args(parser, include_locust_args=True)

--- a/vsb/metrics_tracker.py
+++ b/vsb/metrics_tracker.py
@@ -44,7 +44,7 @@ def print_stats_json(stats: RequestStats) -> None:
     """
     Serialise locust's standard stats, then merge in our custom metrics.
     # Note we replace locust.stats.print_stats_json with this function via
-    # monkey-patching - see vsb.py.
+    # monkey-patching - see vsb/main.py.
     """
     serialized = stats.serialize_stats()
     for s in serialized:


### PR DESCRIPTION
Create a Python package for VSB. This achieves a couple of things:

1. Changes the command to run the program from "./vsb.py" (being in
   the correct cwd) to plain "vsb".

2. A stepping-stone for publishing VSB to pypi and then allowing people to
   install directly via `pip install vsb`.
