### PR TITLE
Fix handling of --loglevel

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -102,7 +102,7 @@ def spawn_vsb_inner(
         "vsb",
         f"--database={database}",
         f"--workload={workload}",
-        "--loglevel=DEBUG",
+        "--loglevel=debug",
     ]
     proc = subprocess.Popen(
         args + extra_args,

--- a/vsb/main.py
+++ b/vsb/main.py
@@ -14,7 +14,8 @@ import vsb.metrics_tracker
 from vsb.cmdline_args import add_vsb_cmdline_args, validate_parsed_args
 
 
-def setup_logging(log_base: Path, level) -> Path:
+def setup_logging(log_base: Path, level: str) -> Path:
+    level = level.upper()
     # Setup the default logger to log to a file under
     # <log_base>/<timestamp>/vsb.log,
     # returning the directory created.


### PR DESCRIPTION
## Problem

The previous patch introduced a bug where --loglevel wasn't handled
correctly for the new rich-based logger, as the loglevel passed was
not converted to uppercase.

## Solution

Fix this.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

