### PR TITLE
Logging: Use vsb.logger

### DIFF
--- a/vsb/users.py
+++ b/vsb/users.py
@@ -126,6 +126,7 @@ class PopulateUser(User):
         if self.user_id == 0:
             # First user only performs finalization (don't want
             # to call repeatedly if >1 user).
+            logger.debug("PopulateUser finalizing population...")
             self.database.finalize_population(self.workload.record_count)
         self.environment.runner.send_message(
             "update_progress", {"user": self.user_id, "phase": "populate"}

--- a/vsb/workloads/__init__.py
+++ b/vsb/workloads/__init__.py
@@ -5,7 +5,7 @@ from .base import VectorWorkload
 @unique
 class Workload(Enum):
     """Set of supported workloads, the value is the string used to
-    specify via --benchmark=
+    specify via --workload=
     """
 
     Mnist = "mnist"

--- a/vsb/workloads/dataset.py
+++ b/vsb/workloads/dataset.py
@@ -244,7 +244,9 @@ class Dataset:
         # (non-empty directories will have their files downloaded
         # anyway).
         blobs = [b for b in blobs if not b.name.endswith("/")]
-        logger.debug(f"Dataset consists of files:{[b.name for b in blobs]}")
+        logger.debug(
+            f"Dataset consists of {len(blobs)} files" f":{[b.name for b in blobs]}"
+        )
 
         def should_download(blob):
             path = self.cache / blob.name


### PR DESCRIPTION
Use vsb.logger instead of the global 'logging' methods, as we only
show messages from the vsb logger to stdout (everything still goes to
the vsg.log file).
