### PR TITLE
Remove dead code from dataset.py

### DIFF
--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -8,21 +8,6 @@ import pytest
 
 
 class TestDataset:
-
-    def test_limit(self):
-        limit = 123
-        name = "mnist"
-        dataset = Dataset(name, limit=limit)
-        # Sanity check that the complete dataset size is greater than what
-        # we are going to limit to.
-        dataset_info = [d for d in dataset.list() if d["name"] == name][0]
-        assert (
-            dataset_info["documents"] > limit
-        ), "Too few documents in dataset to be able to limit"
-
-        dataset.load_documents()
-        assert len(dataset.documents) == limit
-
     def test_get_batch_iter_all(self):
         # Test a batch iter for a single chunk yields the entire dataset.
         dataset = Dataset("mnist")

--- a/vsb/workloads/parquet_workload/parquet_workload.py
+++ b/vsb/workloads/parquet_workload/parquet_workload.py
@@ -30,7 +30,7 @@ class ParquetWorkload(VectorWorkload, ABC):
         super().__init__(name)
         self.dataset = Dataset(dataset_name, cache_dir=cache_dir, limit=limit)
 
-        self.dataset.setup_queries(load_queries=True, query_limit=query_limit)
+        self.dataset.setup_queries(query_limit=query_limit)
         self.queries = self.dataset.queries.itertuples(index=False)
 
     def get_sample_record(self) -> Record:


### PR DESCRIPTION
## Problem

dataset.py was original inherited from another project (locust-pinecone) which had slighly different requirements for parquet
dataset usage. As new functionality has been added in VSB (iterator API, splitting batches), there is now code which is unused in dataset.py:

* Generating queries by sampling passages (where a dataset doesn't have a queries set) - we expect a parquet dataset to always have a query set (and if not the actual workload subclass should provide one).

* Directly upserting a parquet dataset into Pinecone (this is always done via the DB abstract base class to support multiple databases).

## Solution

Delete the code related to this unused functionality to simplify maintenance of VSB.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Rely on existing tests to ensure code is indeed all dead.
