### PR TITLE
dataset: Fix bug where newly-downloaded files were not used

### DIFF
--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -29,7 +29,7 @@ class TestDataset:
         iter = dataset.get_batch_iterator(1, 0, 10)
         assert sum([len(batch) for batch in iter]) == 60000
 
-    def test_get_batch_iter_all(self):
+    def test_get_batch_iter_chunks(self):
         # Test a batch iter for multiple chunks yields the entire dataset.
         dataset = Dataset("mnist")
         # Choosing num_chunks which is not a factor of dataset size, so

--- a/vsb/workloads/dataset.py
+++ b/vsb/workloads/dataset.py
@@ -113,6 +113,7 @@ class Dataset:
         # first N rows into DataFrame, then split / iterate the dataframe.
         assert chunk_id >= 0
         assert chunk_id < num_chunks
+        self._download_dataset_files()
         pq_files = list((self.cache / self.name).glob("passages/*.parquet"))
 
         if self.limit:
@@ -137,7 +138,6 @@ class Dataset:
         else:
             # Need split the parquet files into `num_users` subset of files,
             # then return a batch iterator over the `user_id`th subset.
-            self._download_dataset_files()
             chunks = numpy.array_split(pq_files, num_chunks)
             my_chunks = list(chunks[chunk_id])
             if not my_chunks:


### PR DESCRIPTION
## Problem

In Dataset.get_batch_iterator() with limit=0, the list of files in the dataset was not updated after downloading them from the remote bucket. The effect of this was if the dataset was not cached locally prior to running vsb (i.e. first run), then no dataset files would be found and the iterator would return nothing. 

This was exposed when modifying test_dataset.py to remove a test which essentially 'pre-fetched' the dataset files for a test using get_batch_iterator().

## Solution

Fix by moving the download step earlier, before we set the list of
parquet files.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

