### PR TITLE
Calculate recall based on top_k value

### DIFF
--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,4 +1,5 @@
 from vsb.metrics import Recall
+from vsb.vsb_types import SearchRequest
 
 
 def test_recall_equal():
@@ -19,3 +20,12 @@ def test_recall_actual_fewer_expected():
     assert Recall._calculate(["3"], ["1", "2"]) == 0
     assert Recall._calculate(["1"], ["1", "2", "3", "4"]) == 0.25
     assert Recall._calculate(["1", "2"], ["1", "2", "3", "4"]) == 0.5
+
+
+def test_recall_more_neighbors_than_topk():
+    # Test Recall when the Request has more neighbors present than the specified top_k
+    # - in which case we should only consider the first K elements when calculating
+    # recall.
+    request = SearchRequest(values=[], top_k=1, neighbors=["1", "2"])
+    assert Recall.measure(request, ["1"]) == 1.0
+    assert Recall.measure(request, ["2"]) == 0.0

--- a/vsb/metrics.py
+++ b/vsb/metrics.py
@@ -26,7 +26,7 @@ class Recall(Metric):
 
     @staticmethod
     def measure(request: SearchRequest, results: list[str]) -> float:
-        return Recall._calculate(results, request.neighbors)
+        return Recall._calculate(results, request.neighbors[: request.top_k])
 
     @staticmethod
     def _calculate(actual: list[str], expected: list[str]) -> float:


### PR DESCRIPTION
## Problem

Recall was unexpectedly low when using the cohere-768 workload - instead of values around 0.9, values of 0.01 were seen.

The issue was that the cohere parquet query files include more neighbors (10,000) than the top_k (100) value - and recall was being calculated based on complete neighbors list, even if that's greater than top_k.

## Solution

Fix by limiting the calculation to the top_k value.

Fixes #123.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

New unit test added for this case.
