### PR TITLE
Include current op/s in Run progressbar

### DIFF
--- a/vsb/logging.py
+++ b/vsb/logging.py
@@ -98,6 +98,18 @@ class ProgressIOWrapper(io.IOBase):
         return self.file.seekable()
 
 
+class ExtraInfoProgressBar(rich.progress.Progress):
+    """A specialization of Progress which will display an additional row after a
+    Task if that task has an "extra_info" field.
+    """
+
+    def get_renderables(self):
+        for task in self.tasks:
+            yield self.make_tasks_table([task])
+            if "extra_info" in task.fields:
+                yield rich.console.Text.from_markup(task.fields["extra_info"])
+
+
 def setup_logging(log_base: Path, level: str) -> Path:
     level = level.upper()
     # Setup the default logger to log to a file under
@@ -149,7 +161,7 @@ def make_progressbar() -> rich.progress.Progress:
         task_id = progress.add_task("Task description", total=100)
         progress.update(task_id, advance=1)
     """
-    progress = rich.progress.Progress(
+    progress = ExtraInfoProgressBar(
         rich.progress.TextColumn("[progress.description]{task.description}"),
         rich.progress.MofNCompleteColumn(),
         rich.progress.BarColumn(),
@@ -158,7 +170,6 @@ def make_progressbar() -> rich.progress.Progress:
         rich.progress.TimeElapsedColumn(),
         "[progress.remaining]remaining:",
         rich.progress.TimeRemainingColumn(compact=True),
-        ExtraInfoColumn(),
         console=vsb.console,
     )
     progress.start()

--- a/vsb/users.py
+++ b/vsb/users.py
@@ -397,7 +397,7 @@ class LoadShape(LoadTestShape):
                     env.parsed_options.workload, "Populate"
                 )
                 duration = time.time() - stats.start_time
-                rps_str = "records/sec: {:.1f}".format(completed / duration)
+                rps_str = "  Records/sec: [magenta]{:.1f}".format(completed / duration)
                 vsb.progress.update(
                     self.progress_task_id,
                     completed=completed,
@@ -408,8 +408,13 @@ class LoadShape(LoadTestShape):
                 # TODO: When we add additional request types other than Search,
                 # we need to expand this to include them.
                 env = self.runner.environment
-                stats = env.stats.get(env.parsed_options.workload, "Search")
+                stats: locust.StatsEntry = env.stats.get(
+                    env.parsed_options.workload, "Search"
+                )
 
+                # Display current (last 10s) values for some significant metrics
+                # in the progress_details row.
+                ops_str = f"{stats.current_rps:.1f} op/s"
                 latency_str = ", ".join(
                     [
                         f"p{p}={stats.get_current_response_time_percentile(p/100.0) or '...'}ms"
@@ -427,7 +432,9 @@ class LoadShape(LoadTestShape):
 
                 last_n = locust.stats.CURRENT_RESPONSE_TIME_PERCENTILE_WINDOW
                 metrics_str = (
-                    f"last {last_n}s metrics: [magenta]latency: {latency_str}[/magenta]"
+                    f"  Current metrics (last {last_n}s): [magenta]{ops_str}[/magenta]"
+                    + " | "
+                    + f"[magenta]latency: {latency_str}[/magenta]"
                     + " | "
                     + f"[magenta]recall: {recall_str}"
                 )


### PR DESCRIPTION
Display the current op/s during the Run phase, in addition to the
other metrics.

Note this increases the width of the extra metrics, so reformat the
progressbar so the extra info is shown on the following line (if
present):

    2024-06-19T13:47:42 INFO     Starting Run phase
    ✔ Run complete 10000/10000 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% elapsed: 0:01:44 remaining: 00:00
      Current metrics (last 10s): 96.3 op/s | latency: p50=20ms, p95=22ms | recall: p50=1.00, p5=1.00
