### PR TITLE
Use multipart version of YFCC-10M

### DIFF
--- a/scripts/rewrite_parquet_file_split.py
+++ b/scripts/rewrite_parquet_file_split.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import pyarrow.dataset as ds
+import pyarrow.parquet as pq
+import pyarrow as pa
+import sys
+
+
+def rewrite_parquet_file_with_new_row_group_size(
+    input_file, output_dir, row_group_size, max_rows_per_file
+):
+    # Open the existing Parquet file as Dataset
+    in_dataset = ds.dataset(input_file)
+
+    # Write the batches into the dataset
+    pq.write_to_dataset(
+        in_dataset,
+        basename_template="part-{i}.parquet",
+        root_path=output_dir,
+        row_group_size=row_group_size,
+        max_rows_per_file=max_rows_per_file,
+    )
+
+
+if len(sys.argv) != 5:
+    print(
+        f"Usage: {sys.argv[0]} <input_parquet> <output_parquet_dir> <row_group_size> <max_rows_per_file>"
+    )
+    sys.exit(1)
+
+input_parquet_file = sys.argv[1]
+output_parquet_dir = sys.argv[2]
+row_group_size = int(sys.argv[3])
+max_rows_per_file = int(sys.argv[4])
+
+rewrite_parquet_file_with_new_row_group_size(
+    input_parquet_file, output_parquet_dir, row_group_size, max_rows_per_file
+)

--- a/vsb/logging.py
+++ b/vsb/logging.py
@@ -64,6 +64,10 @@ class ProgressIOWrapper(io.IOBase):
             )
         super().__init__(*args, **kwargs)
 
+    def __del__(self):
+        if self.progress:
+            self.progress.remove_task(self.task_id)
+
     def write(self, b):
         # Write data to the base object
         bytes_written = self.file.write(b)
@@ -164,7 +168,7 @@ def make_progressbar() -> rich.progress.Progress:
     progress = ExtraInfoProgressBar(
         rich.progress.TextColumn(
             "[progress.description]{task.description}",
-            table_column=rich.table.Column(width=25),
+            table_column=rich.table.Column(width=30),
         ),
         rich.progress.MofNCompleteColumn(),
         rich.progress.BarColumn(),

--- a/vsb/workloads/yfcc/yfcc.py
+++ b/vsb/workloads/yfcc/yfcc.py
@@ -17,7 +17,7 @@ class YFCCBase(ParquetWorkload, ABC):
 class YFCC(YFCCBase):
     def __init__(self, name: str, cache_dir: str):
         super().__init__(
-            name, "yfcc-10M-filter-euclidean-formatted", cache_dir=cache_dir
+            name, "yfcc-10M-filter-euclidean-formatted-multipart", cache_dir=cache_dir
         )
 
     @property


### PR DESCRIPTION
## Problem

The version of the YFCC-10M dataset currently used is a single parquet
file; which means the populate phase cannot be parallelised.

## Solution

Split the single file into multiple (100,000 records per file),
allowing concurrent upload. File split with:

    ./rewrite_parquet_file_split.py \
        /tmp/VSB/cache/yfcc-10M-filter-euclidean-formatted/passages/part-0.parquet \
	yfcc-10M-filter-euclidean-formatted-multipart 10000 100000

Also tweak how download progress bars are displayed - with a large
number of files they fill up the screen, so remove a task when the
files is downloaded.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

