### PR TITLE
Output metrics only on successful run

### DIFF
--- a/tests/integration/test_pinecone.py
+++ b/tests/integration/test_pinecone.py
@@ -237,3 +237,15 @@ class TestPinecone:
             "'pinecone':"
         ) in stderr
         assert "--pinecone_api_key" in stderr
+
+    def test_invalid_index(self, api_key):
+        # Tests that specifying an index which doesn't exist is reported gracefully,
+        # without printing additional metrics / stats (which could suggest the expirment ran correctly.
+        (proc, stdout, stderr) = spawn_vsb(
+            workload="mnist-test",
+            api_key=api_key,
+            index_name="index-name-which-does-not-exist",
+        )
+        assert proc.returncode == 2
+        assert "Response time percentiles" not in stdout
+        assert "Saved stats to 'reports/" not in stdout

--- a/vsb/locustfile.py
+++ b/vsb/locustfile.py
@@ -101,6 +101,7 @@ def setup_worker_dataset(environment, **_kwargs):
             # This is a special exception that is raised when we want to
             # stop the User from running, e.g. because the database
             # connection failed.
+            log.unhandled_greenlet_exception = True
             environment.runner.quit()
         except:
             logger.error(

--- a/vsb/metrics_tracker.py
+++ b/vsb/metrics_tracker.py
@@ -14,6 +14,7 @@ import json
 import time
 from collections import defaultdict
 
+import locust.env
 from hdrh.histogram import HdrHistogram
 from locust import events
 from locust.runners import WorkerRunner
@@ -152,10 +153,13 @@ def on_worker_report(client_id, data: dict()):
 
 
 @events.quitting.add_listener
-def print_metrics_on_quitting(environment):
+def print_metrics_on_quitting(environment: locust.env.Environment):
     # Emit stats once on the master (if running in distributed mode) or
     # once on the LocalRunner (if running in single-process mode).
-    if not isinstance(environment.runner, WorkerRunner):
+    if (
+        not isinstance(environment.runner, WorkerRunner)
+        and environment.shape_class.finished
+    ):
         for line in get_stats_summary(environment.stats, False):
             logger.info("    " + line)
         for line in get_percentile_stats_summary(environment.stats):

--- a/vsb/users.py
+++ b/vsb/users.py
@@ -298,6 +298,10 @@ class LoadShape(LoadTestShape):
             case _:
                 raise ValueError(f"Invalid phase:{self.phase}")
 
+    @property
+    def finished(self):
+        return self.phase == LoadShape.Phase.Done
+
     def _transition_phase(self, new: Phase):
         # Record and log the start of the publicly visible phases.
         tracked_phases = [
@@ -375,6 +379,7 @@ class LoadShape(LoadTestShape):
                     )
                     self._transition_phase(LoadShape.Phase.Done)
             case LoadShape.Phase.Done:
+
                 logger.error(
                     f"VSBLoadShape.update_progress() - Unexpected progress update in Done phase!"
                 )
@@ -383,7 +388,6 @@ class LoadShape(LoadTestShape):
         """Update the phase progress bar for the current phase."""
         match self.phase:
             case LoadShape.Phase.Setup:
-                pass
                 vsb.progress.update(
                     self.progress_task_id, total=1, completed=1 if mark_completed else 0
                 )


### PR DESCRIPTION
## Problem

Previously the experiment metrics and stats file was written via the 'quitting' event, so would occur even on unclean exit (Ctrl-C, fatal exception thrown).

This is both misleading (the stats are only partial for the run so far), and verbose / confusing - we print a bunch of text when the user Ctrl-C's the process.

## Solution

Only emit metrics and perform stats file creation if the LoadShape reached the Done phase of the experiment - after all executed phases are correctly executed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

