### PR TITLE
Add --requests_per_sec cmdline option to limit tput

### DIFF
--- a/tests/integration/test_pinecone.py
+++ b/tests/integration/test_pinecone.py
@@ -101,12 +101,12 @@ class TestPinecone:
 
     def test_mnist_concurrent(self, api_key, pinecone_index_mnist):
         # Test "-test" variant of mnist loads and runs successfully with
-        # concurrent users
+        # concurrent users, and with a request limit set.
         (proc, stdout, stderr) = spawn_vsb(
             workload="mnist-test",
             api_key=api_key,
             index_name=pinecone_index_mnist,
-            extra_args=["--users=4"],
+            extra_args=["--users=4", "--requests_per_sec=40"],
         )
         assert proc.returncode == 0
 

--- a/vsb/cmdline_args.py
+++ b/vsb/cmdline_args.py
@@ -38,6 +38,14 @@ def add_vsb_cmdline_args(
         action="store_true",
         help="Skip the populate phase (useful if workload has already been loaded and is static)",
     )
+    general_group.add_argument(
+        "--requests_per_sec",
+        type=float,
+        default=0,
+        help="Target requests per second for the Run phase. If using multiple users, "
+        "then the target will be distributed across all users. "
+        "Specify 0 for unlimited. Default is %(default)s.",
+    )
 
     if include_locust_args:
         general_group.add_argument(
@@ -51,6 +59,8 @@ def add_vsb_cmdline_args(
         general_group.add_argument(
             "--users",
             type=int,
+            metavar="<int>",
+            dest="num_users",
             default=1,
             help="Number of database clients to execute the workload. Default is %("
             "default)s",

--- a/vsb/main.py
+++ b/vsb/main.py
@@ -38,9 +38,12 @@ def main():
 
     log_base = Path("reports") / args.database
     vsb.log_dir = setup_logging(log_base=log_base, level=args.loglevel)
+    requests_per_sec = (
+        "{:g}".format(args.requests_per_sec) if args.requests_per_sec else "unlimited"
+    )
     logger.info(
-        f"Vector Search Bench: Starting experiment with backend='{args.database}' and "
-        f"workload='{args.workload}'."
+        f"Vector Search Bench: Starting experiment with backend='{args.database}', "
+        f"workload='{args.workload}', users={args.num_users}, requests_per_sec={requests_per_sec}"
     )
     logger.info(f"Writing benchmark results to '{vsb.log_dir}'")
 


### PR DESCRIPTION
## Problem

Currently the Run phase just issues requests as quickly as
possible. To be able to run experiments for a wider range of workloads
we need to be able to support running at a specified limit (1 QPS, 10
QPS, ...).

## Solution

This patch adds a new command line argument: --requests_per_sec=N,
which allows the oner to specify the _target_ requests per second
which VSB will issue in the Run phase.

* If there are multiple users configured (--users), then the target is
  split between them - e.g. for --users=4 and --request_per_sec=100,
  each user will attempt to issue 25 requests per second.

* Fractional values can be specified, allowing <1 request per second.

* If a value of 0 is specified (the default) then no limit is imposed
  - requests will be sent as fast as possible (sequentially for each
  user).

Fixes #125.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

