### PR TITLE
Speedup _delete_pinecone_index

### DIFF
--- a/tests/integration/test_pinecone.py
+++ b/tests/integration/test_pinecone.py
@@ -46,7 +46,7 @@ def _create_pinecone_index(dims: int, metric: str) -> str:
 
 def _delete_pinecone_index(index_name: str):
     pc = Pinecone(api_key=read_env_var("PINECONE_API_KEY"))
-    pc.delete_index(name=index_name)
+    pc.delete_index(name=index_name, timeout=-1)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Speedup _delete_pinecone_index() by not waiting for confirmation that the index has been deleted. We don't check the result anyway and this takes ~10s which is just dead time in CI etc.
