### PR TITLE
Execute each query only once when multi-process

### DIFF
--- a/tests/integration/test_pgvector.py
+++ b/tests/integration/test_pgvector.py
@@ -85,10 +85,10 @@ class TestPgvector:
                 # chunk will be less than the batch size (600 / 4 < 1000), then the
                 # number of requests will be equal to the number of users - i.e. 4
                 "Populate": {"num_requests": 4, "num_failures": 0},
-                # TODO: We should only issue each search query once, but currently
-                # we perform the query once per process (2)
+                # The number of Search requests should equal the number in the dataset
+                # (20 for mnist-test).
                 "Search": {
-                    "num_requests": 20 * 2,
+                    "num_requests": 20,
                     "num_failures": 0,
                     "recall": check_recall_stats,
                 },

--- a/tests/integration/test_pinecone.py
+++ b/tests/integration/test_pinecone.py
@@ -145,10 +145,10 @@ class TestPinecone:
                 # chunk will be less than the batch size (600 / 4 < 200), then the
                 # number of requests will be equal to the number of users - i.e. 4
                 "Populate": {"num_requests": 4, "num_failures": 0},
-                # TODO: We should only issue each search query once, but currently
-                # we perform the query once per process (4)
+                # The number of Search requests should equal the number in the dataset
+                # (20 for mnist-test).
                 "Search": {
-                    "num_requests": 20 * 4,
+                    "num_requests": 20,
                     "num_failures": 0,
                     "recall": check_recall_stats,
                 },

--- a/vsb/workloads/base.py
+++ b/vsb/workloads/base.py
@@ -74,9 +74,16 @@ class VectorWorkload(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def next_request(self) -> (str, SearchRequest | None):
-        """Obtain the next request for this workload. Returns a tuple of
-        (tenant, Request), where Request is None if there are no more Requests
-        to issue.
+    def get_query_iter(
+        self, num_users: int, user_id: int
+    ) -> Iterator[tuple[str, SearchRequest]]:
+        """
+        Returns an iterator over the sequence of queries for the given user_id,
+        assuming a total of `num_users` which will be issuing queries - i.e.
+        for the entire query set to be requested there should be `num_users` calls
+        to this method.
+        Returns an Iterator which yields a tuple of (tenant, Request).
+        :param num_users: The number of clients the queries are distributed across.
+        :param user_id: The ID of the user requesting the iterator.
         """
         raise NotImplementedError

--- a/vsb/workloads/dataset.py
+++ b/vsb/workloads/dataset.py
@@ -148,8 +148,6 @@ class Dataset:
             return files_to_batches(my_chunks)
 
     def setup_queries(self, query_limit=0):
-        # If there is an explicit 'queries' dataset, then load that and use
-        # for querying, otherwise use documents directly.
         self._download_dataset_files()
         self.queries = self._load_parquet_dataset("queries", limit=query_limit)
         logger.debug(


### PR DESCRIPTION
## Problem

Each process reads a complete copy of the queries dataset, which is then distributed across all clients running in that process.

This means that with N processes, we will issue the same query N times. This is undesirable as we essentially end up prefetching query results; the second and subsequent execution of the same query will be unrealistically faster as the result was just calculated.

## Solution

Fix by modifying query assignment to be similar to Populate phase - each RunUser is assigned a user_id, and uses that to request a slice of queries for that given user.

Fixes #61.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Intregration tests updated to check for the correct query count.
