### PR TITLE
pgvector: Set ivfflat lists automatically based on recommendations

### DIFF
--- a/vsb/cmdline_args.py
+++ b/vsb/cmdline_args.py
@@ -128,8 +128,10 @@ def add_vsb_cmdline_args(
     pgvector_group.add_argument(
         "--pgvector_ivfflat_lists",
         type=int,
-        default="100",
-        help="For pgvector IVFFLAT indexes, number of lists to create. Default is %(default)s",
+        default=0,
+        help="For pgvector IVFFLAT indexes the number of lists to create. A value of "
+        "0 (default) means to automatically calculate based on the number of "
+        "records R: R/1000 for up to 1M records, sqrt(R) for over 1M records.",
     )
     pgvector_group.add_argument(
         "--pgvector_search_candidates",

--- a/vsb/databases/pgvector/pgvector.py
+++ b/vsb/databases/pgvector/pgvector.py
@@ -168,6 +168,17 @@ class PgvectorDB(DB):
             )
             match self.index_type:
                 case "ivfflat":
+                    if self.ivfflat_lists == 0:
+                        # Automatically calculate number of lists as per
+                        # pgvector docs recommendation.
+                        if record_count <= 1_000_000:
+                            self.ivfflat_lists = max(1, record_count // 1_000)
+                        else:
+                            self.ivfflat_lists = math.isqrt(record_count)
+                        logger.debug(
+                            f"finalize_population: calculated IVFFlat lists:"
+                            f" {self.ivfflat_lists}"
+                        ),
                     sql += f" WITH (lists = {self.ivfflat_lists})"
             self.conn.execute(sql)
 


### PR DESCRIPTION
When using the IVFFlat index type for pgvector, change the default number of lists created from a fixed value (100) to dyanmic value based on the record count, as per the pgvector documentation[1]:

> Choose an appropriate number of lists - a good place to start is
> rows / 1000 for up to 1M rows and sqrt(rows) for over 1M rows

[1]: https://github.com/pgvector/pgvector?tab=readme-ov-file#ivfflat
