### PR TITLE
Set test_dataset cache dir to /tmp/VSB

### DIFF
--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -4,19 +4,20 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
 from vsb.workloads.dataset import Dataset
+from vsb import default_cache_dir
 import pytest
 
 
 class TestDataset:
     def test_get_batch_iter_all(self):
         # Test a batch iter for a single chunk yields the entire dataset.
-        dataset = Dataset("mnist")
+        dataset = Dataset("mnist", cache_dir=default_cache_dir)
         iter = dataset.get_batch_iterator(1, 0, 10)
         assert sum([len(batch) for batch in iter]) == 60000
 
     def test_get_batch_iter_chunks(self):
         # Test a batch iter for multiple chunks yields the entire dataset.
-        dataset = Dataset("mnist")
+        dataset = Dataset("mnist", cache_dir=default_cache_dir)
         # Choosing num_chunks which is not a factor of dataset size, so
         # chunk sizes are uneven.
         num_chunks = 7
@@ -31,7 +32,7 @@ class TestDataset:
         # Test a batch iter for multiple chunks yields the entire dataset when
         # a limit is applied.
         dataset_limit = 1000
-        dataset = Dataset("mnist", limit=dataset_limit)
+        dataset = Dataset("mnist", cache_dir=default_cache_dir, limit=dataset_limit)
         # Choosing num_chunks which is not a factor of dataset size, so
         # chunk sizes are uneven.
         num_chunks = 7

--- a/vsb/__init__.py
+++ b/vsb/__init__.py
@@ -12,6 +12,9 @@ logger = logging.getLogger("vsb")
 log_dir: Path = None
 """Directory where logs will be written to. Set in main()"""
 
+default_cache_dir: str = "/tmp/VSB/cache"
+"""Default directory where datasets are downloaded and cached. Set by cmdline_args."""
+
 console: rich.console.Console = None
 
 progress: rich.progress.Progress = None

--- a/vsb/cmdline_args.py
+++ b/vsb/cmdline_args.py
@@ -1,6 +1,7 @@
 import configargparse
 from vsb.databases import Database
 from vsb.workloads import Workload
+from vsb import default_cache_dir
 
 
 def add_vsb_cmdline_args(
@@ -30,7 +31,7 @@ def add_vsb_cmdline_args(
     general_group.add_argument(
         "--cache_dir",
         type=str,
-        default="/tmp/VSB/cache",
+        default=default_cache_dir,
         help="Directory to store downloaded datasets. Default is %(default)s).",
     )
     general_group.add_argument(


### PR DESCRIPTION
## Problem

The Dataset objects are created with a default empty cache_dir, so the mnist dataset is downloaded into the cwd, and not deleted on termination. #72 

## Solution

Change the cache_dir to "/tmp/VSB/cache" where we store datasets.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

`pytest test_dataset.py` no longer leaves an mnist directory in the project root.
