### PR TITLE
add --workload=help message

### DIFF
--- a/vsb/cmdline_args.py
+++ b/vsb/cmdline_args.py
@@ -1,7 +1,28 @@
 import configargparse
+import argparse
+import rich.table
+import rich.console
 from vsb.databases import Database
 from vsb.workloads import Workload
 from vsb import default_cache_dir
+
+
+class WorkloadHelpAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        if values == "help":
+            table = rich.table.Table(title="Available Workloads")
+            table.add_column("Name", justify="left", no_wrap=True)
+            table.add_column("Record Count", justify="right", style="green")
+            table.add_column("Dimensions")
+            table.add_column("Distance Metric", justify="center")
+            table.add_column("Query Count", justify="right", style="red")
+            for workload in Workload:
+                table.add_row(*tuple(str(x) for x in workload.describe()))
+            console = rich.console.Console()
+            console.print(table)
+            parser.exit(0)
+        else:
+            setattr(namespace, self.dest, values)
 
 
 def add_vsb_cmdline_args(
@@ -22,8 +43,9 @@ def add_vsb_cmdline_args(
     )
     main_group.add_argument(
         "--workload",
+        action=WorkloadHelpAction,
         required=True,
-        choices=tuple(e.value for e in Workload),
+        choices=tuple(e.value for e in Workload) + ("help",),
         help="The workload to run",
     )
 
@@ -170,6 +192,7 @@ def validate_parsed_args(
     If validation fails then parser.error() is called with an appropriate
     message, which will terminate the process.
     """
+
     match args.database:
         case "pinecone":
             required = ("pinecone_api_key", "pinecone_index_name")

--- a/vsb/locustfile.py
+++ b/vsb/locustfile.py
@@ -67,9 +67,9 @@ def setup_runner(env):
     env.workload = Workload(options.workload).build(cache_dir=options.cache_dir)
     logger.info(
         f"Workload '{env.workload.name}' initialized - records"
-        f"={env.workload.record_count}, "
+        f"={env.workload.record_count()}, "
         f"dimensions="
-        f"{env.workload.dimensions}, metric={env.workload.metric.value}"
+        f"{env.workload.dimensions()}, metric={env.workload.metric().value}"
     )
 
 
@@ -92,9 +92,9 @@ def setup_worker_dataset(environment, **_kwargs):
         try:
             options = environment.parsed_options
             environment.database = Database(options.database).get_class()(
-                record_count=environment.workload.record_count,
-                dimensions=environment.workload.dimensions,
-                metric=environment.workload.metric,
+                record_count=environment.workload.record_count(),
+                dimensions=environment.workload.dimensions(),
+                metric=environment.workload.metric(),
                 name=environment.workload.name,
                 config=vars(options),
             )

--- a/vsb/users.py
+++ b/vsb/users.py
@@ -47,8 +47,8 @@ class SetupUser(User):
                     {
                         "user": 0,
                         "phase": "setup",
-                        "record_count": self.environment.workload.record_count,
-                        "request_count": self.environment.workload.request_count,
+                        "record_count": self.environment.workload.record_count(),
+                        "request_count": self.environment.workload.request_count(),
                     },
                 )
                 self.state = self.State.Done
@@ -137,7 +137,7 @@ class PopulateUser(User):
             # First user only performs finalization (don't want
             # to call repeatedly if >1 user).
             logger.debug("PopulateUser finalizing population...")
-            self.database.finalize_population(self.workload.record_count)
+            self.database.finalize_population(self.workload.record_count())
         self.environment.runner.send_message(
             "update_progress", {"user": self.user_id, "phase": "populate"}
         )

--- a/vsb/workloads/__init__.py
+++ b/vsb/workloads/__init__.py
@@ -59,3 +59,14 @@ class Workload(Enum):
                 from .cohere_768.cohere_768 import Cohere768Test
 
                 return Cohere768Test
+
+    def describe(self) -> tuple[str, int, int, str, int]:
+        """Return a tuple with attributes of the workload: name, dataset size, dimensionality, distance metric, and query count."""
+        cls = self._get_class()
+        return (
+            self.value,
+            cls.record_count(),
+            cls.dimensions(),
+            cls.metric().value,
+            cls.request_count(),
+        )

--- a/vsb/workloads/base.py
+++ b/vsb/workloads/base.py
@@ -13,34 +13,34 @@ class VectorWorkload(ABC):
     def name(self) -> str:
         return self._name
 
-    @property
+    @staticmethod
     @abstractmethod
-    def dimensions(self) -> int:
+    def dimensions() -> int:
         """
         The dimensions of (dense) vectors for this workload.
         """
         raise NotImplementedError
 
-    @property
+    @staticmethod
     @abstractmethod
-    def metric(self) -> DistanceMetric:
+    def metric() -> DistanceMetric:
         """
         The distance metric of this workload.
         """
         raise NotImplementedError
 
-    @property
+    @staticmethod
     @abstractmethod
-    def record_count(self) -> int:
+    def record_count() -> int:
         """
         The number of records in the initial workload after population, but
         before issuing any additional requests.
         """
         raise NotImplementedError
 
-    @property
+    @staticmethod
     @abstractmethod
-    def request_count(self) -> int:
+    def request_count() -> int:
         """
         The number of requests in the Run phase of the test.
         """

--- a/vsb/workloads/cohere_768/cohere_768.py
+++ b/vsb/workloads/cohere_768/cohere_768.py
@@ -10,12 +10,12 @@ from ...vsb_types import DistanceMetric
 
 
 class CohereBase(ParquetWorkload, ABC):
-    @property
-    def dimensions(self) -> int:
+    @staticmethod
+    def dimensions() -> int:
         return 768
 
-    @property
-    def metric(self) -> DistanceMetric:
+    @staticmethod
+    def metric() -> DistanceMetric:
         return DistanceMetric.Cosine
 
 
@@ -23,12 +23,12 @@ class Cohere768(CohereBase):
     def __init__(self, name: str, cache_dir: str):
         super().__init__(name, "cohere-768", cache_dir=cache_dir)
 
-    @property
-    def record_count(self) -> int:
+    @staticmethod
+    def record_count() -> int:
         return 10_000_000
 
-    @property
-    def request_count(self) -> int:
+    @staticmethod
+    def request_count() -> int:
         return 1_000
 
 
@@ -41,14 +41,14 @@ class Cohere768Test(ParquetSubsetWorkload, CohereBase):
             name,
             "cohere-768",
             cache_dir=cache_dir,
-            limit=self.record_count,
-            query_limit=self.request_count,
+            limit=self.record_count(),
+            query_limit=self.request_count(),
         )
 
-    @property
-    def record_count(self) -> int:
+    @staticmethod
+    def record_count() -> int:
         return 100_000
 
-    @property
-    def request_count(self) -> int:
+    @staticmethod
+    def request_count() -> int:
         return 100

--- a/vsb/workloads/mnist/mnist.py
+++ b/vsb/workloads/mnist/mnist.py
@@ -8,12 +8,12 @@ import numpy as np
 
 
 class MnistBase(ParquetWorkload, ABC):
-    @property
-    def dimensions(self) -> int:
+    @staticmethod
+    def dimensions() -> int:
         return 784
 
-    @property
-    def metric(self) -> DistanceMetric:
+    @staticmethod
+    def metric() -> DistanceMetric:
         return DistanceMetric.Euclidean
 
 
@@ -21,12 +21,12 @@ class Mnist(MnistBase):
     def __init__(self, name: str, cache_dir: str):
         super().__init__(name, "mnist", cache_dir=cache_dir)
 
-    @property
-    def record_count(self) -> int:
+    @staticmethod
+    def record_count() -> int:
         return 60000
 
-    @property
-    def request_count(self) -> int:
+    @staticmethod
+    def request_count() -> int:
         return 10_000
 
 
@@ -37,10 +37,10 @@ class MnistTest(ParquetSubsetWorkload, MnistBase):
     def __init__(self, name: str, cache_dir: str):
         super().__init__(name, "mnist", cache_dir=cache_dir, limit=600, query_limit=20)
 
-    @property
-    def record_count(self) -> int:
+    @staticmethod
+    def record_count() -> int:
         return 600
 
-    @property
-    def request_count(self) -> int:
+    @staticmethod
+    def request_count() -> int:
         return 20

--- a/vsb/workloads/nq_768_tasb/nq_768_tasb.py
+++ b/vsb/workloads/nq_768_tasb/nq_768_tasb.py
@@ -5,12 +5,12 @@ from ...vsb_types import DistanceMetric
 
 
 class Nq768TasbBase(ParquetWorkload, ABC):
-    @property
-    def dimensions(self) -> int:
+    @staticmethod
+    def dimensions() -> int:
         return 768
 
-    @property
-    def metric(self) -> DistanceMetric:
+    @staticmethod
+    def metric() -> DistanceMetric:
         return DistanceMetric.DotProduct
 
 
@@ -18,13 +18,13 @@ class Nq768Tasb(Nq768TasbBase):
     def __init__(self, name: str, cache_dir: str):
         super().__init__(name, "nq-768-tasb", cache_dir=cache_dir)
 
-    @property
-    def record_count(self) -> int:
+    @staticmethod
+    def record_count() -> int:
         return 2_680_893
 
-    @property
-    def request_count(self) -> int:
-        3_452
+    @staticmethod
+    def request_count() -> int:
+        return 3_452
 
 
 class Nq768TasbTest(ParquetSubsetWorkload, Nq768TasbBase):
@@ -35,10 +35,10 @@ class Nq768TasbTest(ParquetSubsetWorkload, Nq768TasbBase):
             name, "nq-768-tasb", cache_dir=cache_dir, limit=26809, query_limit=35
         )
 
-    @property
-    def record_count(self) -> int:
+    @staticmethod
+    def record_count() -> int:
         return 26809
 
-    @property
-    def request_count(self) -> int:
-        35
+    @staticmethod
+    def request_count() -> int:
+        return 35

--- a/vsb/workloads/yfcc/yfcc.py
+++ b/vsb/workloads/yfcc/yfcc.py
@@ -5,12 +5,12 @@ from ...vsb_types import DistanceMetric
 
 
 class YFCCBase(ParquetWorkload, ABC):
-    @property
-    def dimensions(self) -> int:
+    @staticmethod
+    def dimensions() -> int:
         return 192
 
-    @property
-    def metric(self) -> DistanceMetric:
+    @staticmethod
+    def metric() -> DistanceMetric:
         return DistanceMetric.Euclidean
 
 
@@ -20,12 +20,12 @@ class YFCC(YFCCBase):
             name, "yfcc-10M-filter-euclidean-formatted-multipart", cache_dir=cache_dir
         )
 
-    @property
-    def record_count(self) -> int:
+    @staticmethod
+    def record_count() -> int:
         return 10_000_000
 
-    @property
-    def request_count(self) -> int:
+    @staticmethod
+    def request_count() -> int:
         return 100_000
 
 
@@ -42,10 +42,10 @@ class YFCCTest(ParquetSubsetWorkload, YFCCBase):
             cache_dir=cache_dir,
         )
 
-    @property
-    def record_count(self) -> int:
+    @staticmethod
+    def record_count() -> int:
         return 10_000
 
-    @property
-    def request_count(self) -> int:
+    @staticmethod
+    def request_count() -> int:
         return 500


### PR DESCRIPTION
## Problem

Add a CLI argument (--describe-workloads?) that provides a bit more info about the workload:
Data set size / Dimensions / Distance Metric / Number of queries. Addresses #121 

## Solution
Example output of `vsb --workload=help` (ignore my terminal color lol)
<img width="567" alt="Screenshot 2024-07-02 at 11 27 58 AM" src="https://github.com/pinecone-io/VSB/assets/55215300/680f8b8f-eada-4513-bdba-77c784d01d99">

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)
