### PR TITLE
pgvector: Fix automatic ivfflat lists + skip_populate

### DIFF
--- a/vsb/databases/base.py
+++ b/vsb/databases/base.py
@@ -33,7 +33,12 @@ class DB(ABC):
 
     @abstractmethod
     def __init__(
-        self, dimensions: int, metric: DistanceMetric, name: str, config: dict
+        self,
+        record_count: int,
+        dimensions: int,
+        metric: DistanceMetric,
+        name: str,
+        config: dict,
     ) -> None:
         raise NotImplementedError
 

--- a/vsb/databases/pinecone/pinecone.py
+++ b/vsb/databases/pinecone/pinecone.py
@@ -48,7 +48,12 @@ class PineconeNamespace(Namespace):
 
 class PineconeDB(DB):
     def __init__(
-        self, dimensions: int, metric: DistanceMetric, name: str, config: dict
+        self,
+        record_count: int,
+        dimensions: int,
+        metric: DistanceMetric,
+        name: str,
+        config: dict,
     ):
         self.pc = PineconeGRPC(config["pinecone_api_key"])
         self.skip_populate = config["skip_populate"]

--- a/vsb/locustfile.py
+++ b/vsb/locustfile.py
@@ -92,6 +92,7 @@ def setup_worker_dataset(environment, **_kwargs):
         try:
             options = environment.parsed_options
             environment.database = Database(options.database).get_class()(
+                record_count=environment.workload.record_count,
                 dimensions=environment.workload.dimensions,
                 metric=environment.workload.metric,
                 name=environment.workload.name,


### PR DESCRIPTION
## Problem

As part of #150, `--pgvector_ivfflat_lists` was changed to default to automatically selecting list count based on the number of
records. However, the value was calcuated in finalize_population(), which is not called if `--skip_populate` is passed to VSB.

As such, the combination of using an pgvector with an ivfflat index with automatic #lists resulted in failures at query time, as the number of search candidates in turn is derived from ivfflat_lists:

    psycopg.errors.InvalidParameterValue: 0 is outside the valid range for parameter "ivfflat.probes" (1 .. 32768)

## Solution

Fix by hoisting the calculation of the ivfflat_lists to the __init__ method, so it is always available even if population is skipped.

Fixes #155.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Integration test updated to cover case.
