### PR TITLE
Add --log_dir option

### DIFF
--- a/vsb/cmdline_args.py
+++ b/vsb/cmdline_args.py
@@ -35,6 +35,12 @@ def add_vsb_cmdline_args(
         help="Directory to store downloaded datasets. Default is %(default)s).",
     )
     general_group.add_argument(
+        "--log_dir",
+        "-o",
+        default="reports",
+        help="Directory to write logs to. Default is %(default)s.",
+    )
+    general_group.add_argument(
         "--skip_populate",
         action="store_true",
         help="Skip the populate phase (useful if workload has already been loaded and is static)",

--- a/vsb/main.py
+++ b/vsb/main.py
@@ -36,7 +36,7 @@ def main():
     args = parser.parse_args()
     validate_parsed_args(parser, args)
 
-    log_base = Path("reports") / args.database
+    log_base = Path(args.log_dir) / args.database
     vsb.log_dir = setup_logging(log_base=log_base, level=args.loglevel)
     requests_per_sec = (
         "{:g}".format(args.requests_per_sec) if args.requests_per_sec else "unlimited"


### PR DESCRIPTION
## Problem

We save every report to reports/<database_name>/. This can get cluttered when reports build up.

## Solution

Add a --log_dir, -o option to specify the output directory. This defaults to reports/ so original behavior is conserved.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Run vsb with --log_dir argument and verify that the report is created in the new directory.
