### PR TITLE
Automatically create Pinecone index on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,9 @@ provide suitable credentials to an existing database instance. For example
 to run workload _mnist-test_ against a Pinecone index:
 ```shell
 vsb --database=pinecone --workload=mnist-test \
-    --pinecone_api_key=<API_KEY> \
-    --pinecone_index_name=<INDEX_NAME>
+    --pinecone_api_key=<API_KEY> 
 ```
-Where `--api_key` specifies the [Pinecone](https://app.pinecone.io) API key to use
-and `--index_name` specifies the name of the index to connect to.
-
-> [!TIP]
-> The _mnist-test_ workload has dimensions=784 and metric=euclidean, if you
-> don't have an existing index and need to create one via http://app.pinecone.io.
+Where `--api_key` specifies the [Pinecone](https://app.pinecone.io) API key to use.
 
 #### Local database via Docker
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,7 @@
 import json
 import os
 import random
+import datetime
 import re
 import string
 import subprocess
@@ -15,8 +16,13 @@ def read_env_var(name):
     return value
 
 
-def random_string(length):
-    return "".join(random.choice(string.ascii_lowercase) for _ in range(length))
+def uuid() -> str:
+    """Returns a lowercase unique ID."""
+    now = datetime.datetime.utcnow().replace(microsecond=0).isoformat()
+    now = now.replace(":", "-")
+    randstr = "".join(random.choice(string.ascii_lowercase) for _ in range(10))
+    id = read_env_var("NAME_PREFIX") + "--" + now + "--" + randstr
+    return id.lower()
 
 
 def parse_stats_to_json(stdout: str) -> list(dict()):

--- a/tests/integration/test_pgvector.py
+++ b/tests/integration/test_pgvector.py
@@ -2,18 +2,10 @@ import datetime
 from conftest import (
     check_request_counts,
     read_env_var,
-    random_string,
     spawn_vsb_inner,
     check_recall_stats,
     check_recall_correctness,
 )
-
-
-def _get_index_name() -> str:
-    now = datetime.datetime.utcnow().replace(microsecond=0).isoformat()
-    now = now.replace(":", "-")
-    index_name = read_env_var("NAME_PREFIX") + "--" + now + "--" + random_string(10)
-    index_name = index_name.lower()
 
 
 def spawn_vsb(workload, timeout=60, extra_args=None):

--- a/tests/integration/test_pinecone.py
+++ b/tests/integration/test_pinecone.py
@@ -1,4 +1,3 @@
-import datetime
 import os
 
 import pytest
@@ -7,7 +6,7 @@ from pinecone import Pinecone
 from conftest import (
     check_request_counts,
     read_env_var,
-    random_string,
+    uuid,
     spawn_vsb_inner,
     check_recall_stats,
 )
@@ -26,10 +25,7 @@ def api_key():
 
 def _create_pinecone_index(dims: int, metric: str) -> str:
     pc = Pinecone(api_key=read_env_var("PINECONE_API_KEY"))
-    now = datetime.datetime.utcnow().replace(microsecond=0).isoformat()
-    now = now.replace(":", "-")
-    index_name = read_env_var("NAME_PREFIX") + "--" + now + "--" + random_string(10)
-    index_name = index_name.lower()
+    index_name = uuid()
     environment = os.environ.get("ENVIRONMENT")
     if environment:
         spec = {"pod": {"environment": environment, "pod_type": "p1.x1"}}
@@ -63,13 +59,22 @@ def pinecone_index_yfcc():
     _delete_pinecone_index(index_name)
 
 
-def spawn_vsb(workload, api_key=None, index_name=None, timeout=60, extra_args=None):
+def spawn_vsb(
+    workload,
+    api_key=None,
+    index_name=None,
+    index_spec=None,
+    timeout=60,
+    extra_args=None,
+):
     """Spawn an instance of vsb with the given arguments, returning the proc object,
     its stdout and stderr.
     """
     args = []
     if index_name:
         args += ["--pinecone_index_name", index_name]
+    if index_spec:
+        args += ["--pinecone_index_spec", index_spec]
     if extra_args:
         args += extra_args
     extra_env = {}
@@ -220,14 +225,6 @@ class TestPinecone:
 
     def test_required_args(self, api_key, pinecone_index_mnist):
         # Tests that all required args are correctly checked for at vsb startup.
-        (proc, stdout, stderr) = spawn_vsb(api_key=api_key, workload="mnist-test")
-        assert proc.returncode == 2
-        assert (
-            "The following arguments must be specified when --database is "
-            "'pinecone':"
-        ) in stderr
-        assert "--pinecone_index_name" in stderr
-
         (proc, stdout, stderr) = spawn_vsb(
             index_name=pinecone_index_mnist, workload="mnist-test"
         )
@@ -238,14 +235,27 @@ class TestPinecone:
         ) in stderr
         assert "--pinecone_api_key" in stderr
 
-    def test_invalid_index(self, api_key):
-        # Tests that specifying an index which doesn't exist is reported gracefully,
-        # without printing additional metrics / stats (which could suggest the expirment ran correctly.
+    def test_invalid_index(self, api_key, pinecone_index_mnist):
+        # Tests that specifying an improperly configured index is reported gracefully,
+        # without printing additional metrics / stats (which could suggest the experiment ran correctly.
         (proc, stdout, stderr) = spawn_vsb(
-            workload="mnist-test",
+            workload="yfcc-test",
             api_key=api_key,
-            index_name="index-name-which-does-not-exist",
+            index_name=pinecone_index_mnist,
         )
         assert proc.returncode == 2
         assert "Response time percentiles" not in stdout
         assert "Saved stats to 'reports/" not in stdout
+
+    def test_nonexistent_index(self, api_key):
+        # Tests that specifying an index which doesn't exist informs the user that a new one is created.
+        index_name = uuid()
+        (proc, stdout, stderr) = spawn_vsb(
+            workload="mnist-test",
+            api_key=api_key,
+            index_name=index_name,
+        )
+        _delete_pinecone_index(index_name)
+        assert proc.returncode == 0
+        assert "Creating new index" in stdout
+        assert "Saved stats to 'reports/" in stdout

--- a/vsb/cmdline_args.py
+++ b/vsb/cmdline_args.py
@@ -2,6 +2,8 @@ import configargparse
 import argparse
 import rich.table
 import rich.console
+import json
+from pinecone import ServerlessSpec
 from vsb.databases import Database
 from vsb.workloads import Workload
 from vsb import default_cache_dir
@@ -23,6 +25,20 @@ class WorkloadHelpAction(argparse.Action):
             parser.exit(0)
         else:
             setattr(namespace, self.dest, values)
+
+
+def json_to_pinecone_spec(spec_string):
+    try:
+        spec = json.loads(spec_string)
+        assert "pod" in spec or "serverless" in spec
+        assert len(spec) == 1
+        if "pod" in spec:
+            assert "environment" in spec["pod"] and "pod_type" in spec["pod"]
+        if "serverless" in spec:
+            assert "cloud" in spec["serverless"] and "region" in spec["serverless"]
+        return spec
+    except Exception as e:
+        raise ValueError from e
 
 
 def add_vsb_cmdline_args(
@@ -111,8 +127,16 @@ def add_vsb_cmdline_args(
     pinecone_group.add_argument(
         "--pinecone_index_name",
         type=str,
-        help="Name of Pinecone index to connect to",
+        default=None,
+        help="Name of Pinecone index to connect to. One will be created if it does not exist. Default is vsb-<workload>.",
         env_var="VSB__PINECONE_INDEX_NAME",
+    )
+
+    pinecone_group.add_argument(
+        "--pinecone_index_spec",
+        type=json_to_pinecone_spec,
+        default={"serverless": {"cloud": "aws", "region": "us-east-1"}},
+        help="JSON spec of Pinecone index to create (if it does not exist). Default is %(default)s",
     )
 
     pgvector_group = parser.add_argument_group("Options specific to pgvector database")
@@ -201,7 +225,11 @@ def validate_parsed_args(
 
     match args.database:
         case "pinecone":
-            required = ("pinecone_api_key", "pinecone_index_name")
+            required = (
+                "pinecone_api_key",
+                "pinecone_index_name",
+                "pinecone_index_spec",
+            )
             missing = list()
             for name in required:
                 if not getattr(args, name):

--- a/vsb/databases/pinecone/README.md
+++ b/vsb/databases/pinecone/README.md
@@ -7,15 +7,23 @@ It supports connecting to both Pod-based and Serverless indexes.
 
 To run VSB against a Pinecone index:
 
-1. Create an index via the [Pinecone console](https://app.pinecone.io) with the
-   appropriate dimensionality & metric - e.g. for `mnist-test` use `dimensions=784` and
-   `metric=euclidean`.
-2. Invoke VSB with `--database=pinecone` and provide the API key and index name to VSB.
+1. Invoke VSB with `--database=pinecone` and provide your API key to VSB.
+   A serverless index will be created for you, using aws/us-east-1.
+
+```shell
+vsb --database=pinecone --workload=mnist-test \
+    --pinecone_api_key=<YOUR_API_KEY>
+```
+
+If you wish to configure the created index or use an already existing one,
+specify the name and/or spec with `--pinecone_index_name` and `--pinecone_index_spec`.
+The `--pinecone_index_spec` option takes a JSON string described in the [Pinecone docs](https://docs.pinecone.io/reference/api/control-plane/create_index).
 
 ```shell
 vsb --database=pinecone --workload=mnist-test \
     --pinecone_api_key=<YOUR_API_KEY> \
-    --pinecone_index_name=<YOUR_INDEX_NAME>
+    --pinecone_index_name=<YOUR_INDEX_NAME> \
+    --pinecone_index_spec=<YOUR_INDEX_SPEC>
 ```
 
 > [!TIP]


### PR DESCRIPTION
## Problem

We create a postgres table on startup, but currently users still have to manually create an index for Pinecone. #140 

## Solution

We create an index automatically for Pinecone called vsb-\<workload\>, simplifying usage. Users may still specify existing indexes or customize the created index with --pinecone_index_name and --pinecone_index_spec.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Test with existing/nonexisting indexes, specifying --pinecone_index_name and --pinecone_index_spec, and observing expected effects.
