### PR TITLE
pgvector: Add support for running without an index

### DIFF
--- a/tests/integration/test_pgvector.py
+++ b/tests/integration/test_pgvector.py
@@ -172,6 +172,27 @@ class TestPgvector:
             },
         )
 
+    def test_no_index(self):
+        # Test without an index.
+        # Test "-test" variant of mnist loads and runs successfully, and gives
+        # perfect recall (as Postgres will perform a full kNN scan).
+        (proc, stdout, stderr) = spawn_vsb(
+            workload="mnist-test", extra_args=["--pgvector_index_type=none"]
+        )
+        assert proc.returncode == 0
+
+        check_request_counts(
+            stdout,
+            {
+                "Populate": {"num_requests": 1, "num_failures": 0},
+                "Search": {
+                    "num_requests": 20,
+                    "num_failures": 0,
+                    "recall": check_recall_correctness(1.0),
+                },
+            },
+        )
+
     def test_search_candidates(self):
         # Test pgvector_search_candidates parameter.
         # Test "-test" variant of mnist loads and runs successfully.

--- a/vsb/cmdline_args.py
+++ b/vsb/cmdline_args.py
@@ -150,9 +150,11 @@ def add_vsb_cmdline_args(
     pgvector_group.add_argument(
         "--pgvector_index_type",
         type=str,
-        choices=["ivfflat", "hnsw"],
+        choices=["none", "ivfflat", "hnsw"],
         default="hnsw",
-        help="Index type to use for pgvector. Default is %(default)s",
+        help="Index type to use for pgvector. Specifying 'none' will not create an "
+        "ANN index, instead brute-force kNN search will be performed."
+        "Default is %(default)s",
     )
     pgvector_group.add_argument(
         "--pgvector_ivfflat_lists",


### PR DESCRIPTION
If an pgvector index is not created, then Postgres will perform an exact, exhaustive search. This is typically (much) slower than using an index, but it does guarantee perfect recall.

As such, this can be a useful mode for development / testing datasets, or even establishing a baseline of how Postgres behaves when no index is used.

Add support for not running with an index by adding the 'none' option to --pgvector_index_type.
