### PR TITLE
Remove required restriction on --pinecone_index_name

### DIFF
--- a/vsb/cmdline_args.py
+++ b/vsb/cmdline_args.py
@@ -229,7 +229,6 @@ def validate_parsed_args(
         case "pinecone":
             required = (
                 "pinecone_api_key",
-                "pinecone_index_name",
                 "pinecone_index_spec",
             )
             missing = list()


### PR DESCRIPTION
## Problem

When pushing the automatic Pinecone index creation feature, the default action (when --pinecone_index_name was not passed) was broken. The command would error as the flag was still marked as "required".

## Solution

Remove the flag from the required args for Pinecone

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
