### PR TITLE
Fix finalize after load

### DIFF
--- a/vsb/locustfile.py
+++ b/vsb/locustfile.py
@@ -32,7 +32,7 @@ import locust.stats
 # Note: These are _not_ unused, they are required to register our User
 # and custom LoadShape classes with locust.
 import users
-from users import SetupUser, PopulateUser, RunUser, LoadShape
+from users import SetupUser, PopulateUser, FinalizeUser, RunUser, LoadShape
 
 # Display stats of benchmark so far to console very 5 seconds.
 locust.stats.CONSOLE_STATS_INTERVAL_SEC = 5
@@ -51,7 +51,7 @@ def setup_environment(environment, **_kwargs):
     options = env.parsed_options
     num_users = options.num_users or 1
 
-    logger.debug(f"on_locust_init(): runner={type(environment.runner)}")
+    logger.debug(f"setup_environment(): runner={type(environment.runner)}")
 
     # Load the WorkloadSequence
     if isinstance(environment.runner, MasterRunner):

--- a/vsb/metrics_tracker.py
+++ b/vsb/metrics_tracker.py
@@ -250,7 +250,7 @@ def get_metrics_stats_summary(stats: RequestStats) -> rich.table.Table:
             table.add_row(*row)
         request = key[1]
         # Also include any custom metrics for this request type.
-        if custom := calculated_metrics.get(r.name, dict()).get(request, None):
+        if custom := calculated_metrics.get(request, None):
             for metric, value in custom.items():
                 if isinstance(value, HdrHistogram):
                     row = [


### PR DESCRIPTION
## Problem

When doing multi-user runs, PopulateUsers independently complete their load and then the PopulateUser with a uid of 1 starts finalizing once its own load has completed. There's a race condition in pgvector (finalize_population issues a CREATE INDEX command), where if PopulateUser 1 finishes before other Users, it will start the command immediately and potentially block other inserts until it has finished, leading to unexpected results (the last chunk of vectors is inserted post-index creation). #196 

## Solution

Add separate FinalizeUser so finalization occurs explicitly after all Populate users have finished upserting, avoiding a race condition in multi-user runs.
    
Finalize phase is also a separate phase in time benchmarking, which is useful for measuring the specific index creation time for databases like pgvector, outside of normal upserting time.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

All existing tests should retain functionality.
