### PR TITLE
fix recall table row order

### DIFF
--- a/vsb/metrics_tracker.py
+++ b/vsb/metrics_tracker.py
@@ -259,11 +259,11 @@ def get_metrics_stats_summary(stats: RequestStats) -> rich.table.Table:
                     row = [
                         request,
                         metric.capitalize(),
+                        f"{value.get_min_value() / HDR_SCALE_FACTOR:.2f}",
                         *[
                             f"{value.get_value_at_percentile(p * 100) / HDR_SCALE_FACTOR:.2f}"
                             for p in REPORT_PERCENTILES
                         ],
-                        f"{value.get_min_value() / HDR_SCALE_FACTOR:.2f}",
                         f"{value.get_max_value() / HDR_SCALE_FACTOR:.2f}",
                         f"{value.get_mean_value() / HDR_SCALE_FACTOR:.2f}",
                     ]


### PR DESCRIPTION
## Problem

For additional stats (like Recall), the column order was misaligned by 1 leading to misleading results. (Minimum value was entered after percentiles, and not before like the table suggests.

<img width="735" alt="Screenshot 2024-07-24 at 12 43 21 PM" src="https://github.com/user-attachments/assets/ee4428ee-79d3-4656-b456-ea69ca85ce74">

(Notice how 99.99% is only 0.63 (actually the min), when the "minimum" is 0.93 - actually 0.1%)

## Solution

Switch order

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan
