### PR TITLE
Add MAP and MRR metrics reporting

### DIFF
--- a/tests/integration/test_pgvector.py
+++ b/tests/integration/test_pgvector.py
@@ -30,7 +30,7 @@ class TestPgvector:
                 "Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
             },
         )
@@ -55,7 +55,7 @@ class TestPgvector:
                 "Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
             },
         )
@@ -82,7 +82,7 @@ class TestPgvector:
                 "Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
             },
         )
@@ -101,13 +101,13 @@ class TestPgvector:
                 "test1.Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
                 "test2.Populate": {"num_requests": 1, "num_failures": 0},
                 "test2.Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
             },
         )
@@ -134,13 +134,13 @@ class TestPgvector:
                 "test1.Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
                 "test2.Populate": {"num_requests": 4, "num_failures": 0},
                 "test2.Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
             },
         )
@@ -167,13 +167,13 @@ class TestPgvector:
                 "test1.Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
                 "test2.Populate": {"num_requests": 4, "num_failures": 0},
                 "test2.Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
             },
         )
@@ -209,7 +209,7 @@ class TestPgvector:
                 "Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
             },
         )
@@ -229,7 +229,7 @@ class TestPgvector:
                 "Search": {
                     "num_requests": 500,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
             },
         )
@@ -250,7 +250,7 @@ class TestPgvector:
                 "Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
             },
         )
@@ -271,7 +271,7 @@ class TestPgvector:
                 "Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": check_recall_correctness(1.0),
+                    "Recall": check_recall_correctness(1.0),
                 },
             },
         )
@@ -291,7 +291,7 @@ class TestPgvector:
                 "Search": {
                     "num_requests": 500,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
             },
         )
@@ -311,7 +311,7 @@ class TestPgvector:
                 "Search": {
                     "num_requests": 500,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
             },
         )
@@ -331,7 +331,7 @@ class TestPgvector:
                 "Search": {
                     "num_requests": 500,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
             },
         )
@@ -356,7 +356,7 @@ class TestPgvector:
                 "Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": check_recall_correctness(0.9),
+                    "Recall": check_recall_correctness(0.9),
                 },
             },
         )

--- a/tests/integration/test_pinecone.py
+++ b/tests/integration/test_pinecone.py
@@ -99,7 +99,7 @@ class TestPinecone:
                 "Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
             },
         )
@@ -126,7 +126,7 @@ class TestPinecone:
                 "Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
             },
         )
@@ -155,7 +155,7 @@ class TestPinecone:
                 "Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
             },
         )
@@ -178,13 +178,13 @@ class TestPinecone:
                 "test1.Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
                 "test2.Populate": {"num_requests": 2, "num_failures": 0},
                 "test2.Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
             },
         )
@@ -213,13 +213,13 @@ class TestPinecone:
                 "test1.Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
                 "test2.Populate": {"num_requests": 4, "num_failures": 0},
                 "test2.Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
             },
         )
@@ -248,13 +248,13 @@ class TestPinecone:
                 "test1.Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
                 "test2.Populate": {"num_requests": 4, "num_failures": 0},
                 "test2.Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
             },
         )
@@ -275,7 +275,7 @@ class TestPinecone:
                 "Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
             },
         )
@@ -295,7 +295,7 @@ class TestPinecone:
                 "Search": {
                     "num_requests": 20,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
             },
         )
@@ -317,7 +317,7 @@ class TestPinecone:
                 "Search": {
                     "num_requests": 500,
                     "num_failures": 0,
-                    "recall": check_recall_stats,
+                    "Recall": check_recall_stats,
                 },
             },
         )

--- a/vsb/metrics.py
+++ b/vsb/metrics.py
@@ -22,7 +22,7 @@ class Recall(Metric):
 
     @staticmethod
     def name():
-        return "recall"
+        return "Recall"
 
     @staticmethod
     def measure(request: SearchRequest, results: list[str]) -> float:
@@ -59,14 +59,19 @@ class AveragePrecision(Metric):
                 return 1.0
             # If we expect [] and receive vectors, the result is (fully) incorrect.
             return 0.0
-        relevant = set(expected)
-        num_true_positives = 0
+        if not actual:
+            # If we expect vectors and receive [], the result is (fully) incorrect.
+            return 0.0
+        relevant = set()
+        so_far = set()
         precision = 0
         for i, result in enumerate(actual):
-            if result in relevant:
-                num_true_positives += 1
+            so_far.add(result)
+            if i < len(expected):
+                relevant.add(expected[i])
+            num_true_positives = len(so_far & relevant)
             precision += num_true_positives / (i + 1)
-        return precision / len(expected)
+        return precision / len(actual)
 
 
 class ReciprocalRank(Metric):


### PR DESCRIPTION
#201 

Adds Mean Average Precision and Mean Reciprocal Rank as metrics. Calculates Average Precision and Reciprocal Rank for each query individually, like Recall, and spits out the full distribution including the "MeanXX" statistic in the "Mean" column.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

New tests made for Average Precision and Reciprocal Rank
