### PR TITLE
Turn off "no metadata" warning for non-GIN indexes

### DIFF
--- a/vsb/databases/pgvector/pgvector.py
+++ b/vsb/databases/pgvector/pgvector.py
@@ -41,7 +41,7 @@ class PgvectorNamespace(Namespace):
 
         # Warn the user once if they're using a GIN index on a
         # dataset that doesn't have metadata.
-        if not self.warned_no_metadata:
+        if not self.warned_no_metadata and "gin" in self.index_type:
             if all([rec.metadata is None for rec in batch]):
                 self.warned_no_metadata = True
                 logger.warning(


### PR DESCRIPTION
## Problem

The no metadata warning for pgvector would fire on every workload without metadata, regardless of index type

## Solution

Check that we're using a GIN index before warning.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan


