### PR TITLE
Make test_euclidean use non-equal values

### DIFF
--- a/tests/unit/test_parquet_workload.py
+++ b/tests/unit/test_parquet_workload.py
@@ -1,8 +1,7 @@
 import pandas
 import pytest
 
-import vsb
-from vsb.vsb_types import DistanceMetric, Record, RecordList, SearchRequest
+from vsb.vsb_types import DistanceMetric, SearchRequest
 from vsb.workloads.parquet_workload.parquet_workload import ParquetSubsetWorkload
 
 
@@ -10,19 +9,19 @@ class TestSubsetWorkloadKNN:
     records = pandas.DataFrame(
         [
             {"id": "a", "values": [2, 0, 0]},
-            {"id": "b", "values": [0, 2, 0]},
+            {"id": "b", "values": [0, 1.9, 0]},
             {"id": "c", "values": [5, 5, 0]},
             {"id": "d", "values": [-1, 0, 2]},
-            {"id": "e", "values": [0, 5, 5]},
-            {"id": "f", "values": [0, 2, 2]},
+            {"id": "e", "values": [-0.1, 5, 5.1]},
+            {"id": "f", "values": [0, 2, 2.1]},
         ]
     )
 
     queries = pandas.DataFrame(
         [
             {"values": [10, 0.5, 0], "top_k": 3},
-            {"values": [-1, 0.1, 1], "top_k": 3},
-            {"values": [0, 5, 2], "top_k": 2},
+            {"values": [-1, 0.2, 1], "top_k": 3},
+            {"values": [0, 5.2, 2.1], "top_k": 2},
         ]
     )
 


### PR DESCRIPTION
## Problem

In test_euclidean, records "e" and "f" both had identical euclidean
distance from the 3rd query vector (3.0). This meant the test
assertion was brittle as it depended on the order that two identical
values were sorted.

## Solution

Fix the test by giving "e" and "f" non-identical distances (2.9 and
3.25) so the top_k will always be correct.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Describe specific steps for validating this change.
