### PR TITLE
Fix issues with --synthetic_metadata parsing, expand examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,12 +173,28 @@ range of vector databases. It can be used to perform a range of tasks, including
 ### Synthetic Workloads
 
 Sometimes the workload you want to model doesn't exist in any provided dataset, or you want
-to test a specific aspect of a database's performance. In these cases, you can use the `synthetic`, `synthetic-runbook`, 
-and `synthetic-proportional` workloads to generate custom workloads with specific characteristics. Some
-important parameters for synthetic workloads include:
+to test a specific aspect of a database's performance. In these cases, you can use 
+a _synthetic_ workload to generate custom workloads with specific 
+characteristics.
+
+There are three modes of synthetic workloads, however the most common is the 
+`synthetic-proportional` workload: 
+
+* `synthetic-proportional` workloads populate the database with an initial set of 
+records, then run a series of assorted request operations (inserts, queries, deletes, updates) in proportion to the given ratios.
+
+* `synthetic` workloads generate a fixed number of records and queries with the given 
+distribution, then runs population and query phases in sequence.
+
+* `synthetic-runbook` workloads generate a fixed number of records and queries, and 
+splits them into a series of multiple 'populate -> run' steps. This is useful 
+  for testing how a database performs when data is loaded incrementally.
+
+Some important parameters for synthetic workloads include:
 
 * `--synthetic_records`: The number of records to generate for the synthetic workload.
-* `--synthetic_requests`: The number of requests to generate for the synthetic workload.
+* `--synthetic_requests`: The number of requests to generate for the run phase of 
+  the synthetic workload.
 * `--synthetic_dimensions`: The dimensionality of generated vectors.
 * `--synthetic_query_distribution`: The distribution of query/fetch IDs for synthetic proportional workloads.
 * `--synthetic_record_ratio`: The distribution of record vectors in space for synthetic proportional workloads.
@@ -186,34 +202,39 @@ important parameters for synthetic workloads include:
 * `--synthetic_query_ratio`: The proportion of query operations for synthetic proportional workloads.
 * `--synthetic_metadata`: The metadata schema to use for each record.
 
-Metadata is specified by providing multiple `--synthetic_metadata` flags describing a metadata field
-with a key and supported value. Values can be `<# digits>n` for a random integer, `<# chars>s` for a
-random string, `<# chars>s<# strings>l` for a random list of strings, or `b` for a random boolean.
+#### **Defining Synthetic Metadata**
 
-For example, `--synthetic_metadata=id:10n` generates a metadata field `id` with a random 10-digit integer.
-`--synthetic_metadata=tags:5s10l` generates a metadata field `tags` with a list of 10 ranodm strings, each 
-5 characters long. `--synthetic_metadata=active:b` generates a metadata field `active` with a random boolean.
+Metadata can optionally be generated for each record in a synthetic workload. 
+Metadata is specified using one or more `--synthetic_metadata` flags. Each flag 
+defines a *metadata field* with a *name* and a *format specification*.
+
+##### **Supported Metadata Types**
+| Type | Format Spec            | Example |
+|------|------------------------|---------|
+| Random integer with `#` digits | `<# digits>n`          | `id:10n` → `{"id": 1234567890}` |
+| Random alphanumeric string of `#` characters | `<# chars>s`           | `username:8s` → `{"username": "aZb3Xy91"}` |
+| List of `<# items>` strings, each of length `<# chars>` | `<# chars>s<# items>l` | `tags:5s10l` → `{"tags": ["apple", "delta", "omega", ...]}` |
+| Random boolean (`true` or `false`) | `b`                    | `active:b` → `{"active": true}` |
+
+##### **Example Metadata Usage**
+- `--synthetic_metadata=id:10n` → Generates a numeric `id` with 10 random digits*
+- `--synthetic_metadata=tags:5s10l` → Generates a `tags` field containing a list of 10 random words, each 5 characters long.
+- `--synthetic_metadata=username:8s` → Generates a random username with 8 characters.
+- `--synthetic_metadata=active:b` → Generates an active/inactive flag as `true` or `false`.
 
 You can see the full list of parameters by running `vsb --help`.
 
-`synthetic` workloads generate a fixed number of records and queries with the given distribution, then
-runs population and query phases in sequence.
-
-`synthetic-runbook` workloads generate a fixed number of records and queries, and splits them into a series of 
-'populate -> run' steps. This is useful for testing how a database performs when data is loaded incrementally.
-
-`synthetic-proportional` workloads populate the database with an initial set of records, then run a series of
-assorted request operations (inserts, queries, deletes, updates) in proportion to the given ratios.
 
 **Example**
 
-The following command runs a synthetic workload against Pinecone, with 10,000 initial records,
-a zipfian query distribution, and 30% inserts, 50% queries, 10% deletes, and 10% updates:
+The following command runs a synthetic workload against Pinecone, with 1,000 initial records,
+then performs 100 requests in a zipfian query distribution, made up of 30% inserts, 
+50% queries, 10% deletes, and 10% updates:
 
 ```shell
 vsb --database=pinecone --pinecone_api_key=<API_KEY> \
     --workload=synthetic-proportional \
-    --synthetic_records=10000 --synthetic_requests=1000000 \
+    --synthetic_records=1000 --synthetic_requests=100 \
     --synthetic_insert_ratio=0.3 --synthetic_query_ratio=0.5 \
     --synthetic_delete_ratio=0.1 --synthetic_update_ratio=0.1 \
     --synthetic_dimensions=768 --synthetic_query_distribution=zipfian \

--- a/tests/unit/test_synthetic_workload.py
+++ b/tests/unit/test_synthetic_workload.py
@@ -1,0 +1,76 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from vsb.workloads.synthetic_workload.synthetic_workload import (
+    SyntheticProportionalWorkload,
+)
+import pytest
+import numpy as np
+
+
+class TestSyntheticMetadata:
+    @pytest.fixture
+    def rng(self):
+        """Provides a random generator instance for testing."""
+        return np.random.default_rng(42)
+
+    def test_string_generator(self, rng):
+        """Test that the string generator produces fixed-length alphanumeric strings."""
+        generator = SyntheticProportionalWorkload.make_string_generator(10)
+        result = generator(rng)
+        assert isinstance(result, str)
+        assert len(result) == 10
+        assert all(c.isalnum() for c in result)
+
+    def test_list_generator(self, rng):
+        """Test that the list generator produces a list of n strings of length m."""
+        generator = SyntheticProportionalWorkload.make_list_generator(5, 3)
+        result = generator(rng)
+        assert isinstance(result, list)
+        assert len(result) == 3
+        assert all(isinstance(s, str) and len(s) == 5 for s in result)
+
+    def test_numeric_generator(self, rng):
+        """Test that the numeric generator produces an integer with the expected digit count."""
+        generator = SyntheticProportionalWorkload.make_numeric_generator(5)
+        result = generator(rng)
+        assert isinstance(result, int)
+        assert result < 10000  # Ensures a 5-digit number
+
+    def test_boolean_generator(self, rng):
+        """Test that the boolean generator produces True or False."""
+        generator = SyntheticProportionalWorkload.make_boolean_generator()
+        result = generator(rng)
+        assert isinstance(result, bool)
+
+    def test_parse_synthetic_metadata_template(self, rng):
+        """Test full metadata parsing and generation."""
+        metadata_template = ["id:10n", "tags:5s10l", "flag:b", "username:8s"]
+        generators = SyntheticProportionalWorkload.parse_synthetic_metadata_template(
+            metadata_template
+        )
+
+        # Ensure correct generator keys exist
+        assert set(generators.keys()) == {"id", "tags", "flag", "username"}
+
+        # Generate metadata
+        metadata = {key: gen(rng) for key, gen in generators.items()}
+
+        # Validate "id" as a numeric value with 10 digits
+        assert isinstance(metadata["id"], int)
+        assert metadata["id"] < 10**10  # Ensures a 10-digit number
+
+        # Validate "tags" as a list of 10 strings, each of length 5
+        assert isinstance(metadata["tags"], list)
+        assert len(metadata["tags"]) == 10
+        assert all(isinstance(tag, str) and len(tag) == 5 for tag in metadata["tags"])
+
+        # Validate "flag" as a boolean
+        assert isinstance(metadata["flag"], bool)
+
+        # Validate "username" as a string of length 8
+        assert isinstance(metadata["username"], str)
+        assert len(metadata["username"]) == 8
+        assert all(c.isalnum() for c in metadata["username"])  # Ensure alphanumeric


### PR DESCRIPTION
## Problem

`--synthetic_metadata` was not parsed correctly if multiple instances of synthetic_metadata were passed, due to the use of lambdas in the metadata generator parser - they captured the initial value of the arguments passed, which had the effect of subsequent --synthetic_metadata fields using the "wrong" values.

## Solution

Fix by replacing these with normal functions; then add tests to cover each metadata field type.

Also expand the documentation for synthetic metadata, hopefully make it easier for users to make use of.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
