### PR TITLE
Add jitter to when each RunUser starts

### DIFF
--- a/tests/unit/test_randomized_pacer.py
+++ b/tests/unit/test_randomized_pacer.py
@@ -1,0 +1,119 @@
+import os
+import sys
+import time
+import unittest
+from unittest.mock import patch, MagicMock
+import statistics
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from vsb.randomized_pacer import RandomizedPacer
+import pytest
+
+
+class TestRandomizedPacer:
+    def test_init(self):
+        pacer = RandomizedPacer(1.0)
+        assert pacer.target_rps == 1.0
+
+    def test_zero_rps(self):
+        # When target_rps is 0, wait_time should return 0
+        pacer = RandomizedPacer(0.0)
+        assert pacer.wait_time() == 0
+
+    @patch("time.time")
+    def test_behind_schedule(self, mock_time):
+        # Test when we're behind schedule
+        mock_time.return_value = 100.0
+        pacer = RandomizedPacer(1.0)
+
+        # Now we're 2 seconds behind
+        mock_time.return_value = 102.0
+
+        with patch("random.random", return_value=0.5):
+            wait = pacer.wait_time()
+            assert wait == 0.0  # Should return 0 when behind schedule
+
+    def test_long_term_rate_stability(self):
+        # Test that over many calls, the average rate is maintained
+        # This test mocks time to make it deterministic
+        with patch("time.time") as mock_time:
+            current_time = 1000.0
+            mock_time.return_value = current_time
+
+            pacer = RandomizedPacer(10.0)  # Target: 10 req/sec
+            wait_times = []
+
+            # Simulate many requests with mocked time
+            samples = 10000  # Large sample for statistical confidence
+            for _ in range(samples):
+                wait = pacer.wait_time()
+                wait_times.append(wait)
+                current_time += wait
+                mock_time.return_value = current_time
+
+            # Calculate effective rate
+            total_time = sum(wait_times)
+            effective_rps = samples / total_time if total_time > 0 else float("inf")
+
+            # Rate should be close to target (allowing for some variation)
+            assert (
+                9.5 <= effective_rps <= 10.5
+            ), f"Effective rate {effective_rps} is too far from target 10.0"
+
+    def test_wait_time_distribution(self):
+        """
+        Test that wait times are properly distributed and maintain the target rate.
+
+        This test validates:
+        1. Wait times are properly randomized (not all the same)
+        2. The overall request rate matches the target rate
+        3. The distribution has expected statistical properties
+        """
+        with patch("time.time") as mock_time:
+            current_time = 1000.0
+            mock_time.return_value = current_time
+
+            # Create a pacer with 1 request per second
+            pacer = RandomizedPacer(1.0)
+
+            # Collect wait times and timestamps
+            wait_times = []
+            timestamps = [current_time]  # Start with initial time
+
+            for _ in range(1000):
+                wait = pacer.wait_time()
+                wait_times.append(wait)
+
+                # Simulate time passing exactly by the wait duration
+                current_time += wait
+                mock_time.return_value = current_time
+                timestamps.append(current_time)
+
+        # Verify wait times are non-negative
+        assert min(wait_times) >= 0, "Wait times should not be negative"
+
+        # Verify wait times are randomized (have variance)
+        assert statistics.stdev(wait_times) > 0.05, "Wait times should be distributed"
+
+        # Verify the mean wait time is close to the expected interval
+        # With 1000 samples, it should be very close to the target interval of 1 second
+        mean_wait = statistics.mean(wait_times)
+        assert (
+            0.95 <= mean_wait <= 1.05
+        ), f"Mean wait time {mean_wait} should be close to 1.0 second"
+
+        # Verify the request rate over the entire period matches the target
+        total_time = timestamps[-1] - timestamps[0]
+        req_per_sec = 1000 / total_time
+        assert (
+            0.95 <= req_per_sec <= 1.05
+        ), f"Request rate {req_per_sec} should be close to 1.0"
+
+        # Verify successive wait times aren't too strongly correlated
+        # (which would indicate poor randomization)
+        successive_diffs = [
+            abs(wait_times[i] - wait_times[i - 1]) for i in range(1, len(wait_times))
+        ]
+        avg_diff = statistics.mean(successive_diffs)
+        assert avg_diff > 0.1, "Wait times should vary between successive requests"

--- a/tests/unit/test_randomized_pacer.py
+++ b/tests/unit/test_randomized_pacer.py
@@ -1,8 +1,6 @@
 import os
 import sys
-import time
-import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 import statistics
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
@@ -41,11 +39,11 @@ class TestRandomizedPacer:
             current_time = 1000.0
             mock_time.return_value = current_time
 
-            pacer = RandomizedPacer(10.0)  # Target: 10 req/sec
+            pacer = RandomizedPacer(10.0)
             wait_times = []
 
             # Simulate many requests with mocked time
-            samples = 10000  # Large sample for statistical confidence
+            samples = 1000  # Large sample for statistical confidence
             for _ in range(samples):
                 wait = pacer.wait_time()
                 wait_times.append(wait)

--- a/vsb/randomized_pacer.py
+++ b/vsb/randomized_pacer.py
@@ -1,0 +1,53 @@
+import time
+import random
+
+
+class RandomizedPacer:
+    """
+    Maintains a consistent average request rate while randomizing exact request timing
+    to avoid coordination between multiple instances.
+    """
+
+    def __init__(self, target_rps):
+        """
+        Initialize pacing controller with target requests per second.
+        """
+        self.target_rps = target_rps
+        self.next_expected_time = time.time()
+
+    def wait_time(self):
+        """
+        Calculate wait time for next request, introducing randomization while
+        maintaining the target throughput over time.
+
+        Returns:
+            float: Time to wait in seconds before next request
+        """
+        now = time.time()
+
+        # Calculate ideal time between requests
+        interval = 1.0 / self.target_rps if self.target_rps > 0 else 0
+
+        # If we're behind schedule, don't wait
+        if now >= self.next_expected_time:
+            # Schedule the next request one interval from now
+            self.next_expected_time = now + interval
+            return 0
+
+        # Calculate wait time to next expected request (assuming exact target
+        # rate)
+        wait = self.next_expected_time - now
+
+        # Introduce randomization: instead of waiting the full time,
+        # we'll wait a random amount between 0 and 2*wait - i.e. on average
+        # we wait for `wait` seconds, maintaining the target rate.
+        random_factor = random.random() * 2.0
+        randomized_wait = wait * random_factor
+
+        # Schedule the next expected request time:
+        # 1. Move forward by one full interval
+        # 2. Adjust for the randomization to maintain the average rate
+        adjustment = wait - randomized_wait
+        self.next_expected_time = self.next_expected_time + interval - adjustment
+
+        return max(randomized_wait, 0)

--- a/vsb/randomized_pacer.py
+++ b/vsb/randomized_pacer.py
@@ -39,9 +39,13 @@ class RandomizedPacer:
         wait = self.next_expected_time - now
 
         # Introduce randomization: instead of waiting the full time,
-        # we'll wait a random amount between 0 and 2*wait - i.e. on average
-        # we wait for `wait` seconds, maintaining the target rate.
-        random_factor = random.random() * 2.0
+        # we'll wait a random amount 0.5x and 1.5x wait - i.e. on average
+        # we wait for `wait` seconds, thus maintaining the target rate over time.
+        # (0.5x - 1.5x is chosen instead of say 0 - 2.0x to reduce the variance
+        # in the request rate, particulary for small test durations / number of
+        # users - this should still be sufficiently uncorrelated for typical
+        # workloads).
+        random_factor = 0.5 + random.random()
         randomized_wait = wait * random_factor
 
         # Schedule the next expected request time:

--- a/vsb/randomized_pacer.py
+++ b/vsb/randomized_pacer.py
@@ -39,8 +39,9 @@ class RandomizedPacer:
         wait = self.next_expected_time - now
 
         # Introduce randomization: instead of waiting the full time,
-        # we'll wait a random amount 0.5x and 1.5x wait - i.e. on average
-        # we wait for `wait` seconds, thus maintaining the target rate over time.
+        # we'll wait a random amount between 0.5x - 1.5x of wait - i.e. on
+        # average we wait for `wait` seconds, thus maintaining the target rate
+        # over time.
         # (0.5x - 1.5x is chosen instead of say 0 - 2.0x to reduce the variance
         # in the request rate, particulary for small test durations / number of
         # users - this should still be sufficiently uncorrelated for typical

--- a/vsb/users.py
+++ b/vsb/users.py
@@ -281,7 +281,6 @@ class RunUser(User):
             # each user.
             gevent.sleep(1.0 / self.target_throughput)
 
-
         tenant: str = None
         request: QueryRequest = None
         try:


### PR DESCRIPTION
## Problem

When running with multiple users (`--users=N`) and a fixed operation rate (`--requests_per_sec=R`), requests from different users will initially be coordinated with each other - we spawn N greenlets, then each greenlet issues the first request as soon as possible, then sleeps for `1 / per_user_requests_per_sec`, then issues the next request, etc. This results in N requests hitting the DB at the ~same time. This can result in artificially "bursty" requests to the DB, particulary when users is high compared to the requests_per_sec.

## Solution

Address this by introducing a random delay when each user starts, between 0 and the period of each request for this user. 

Comparing the graph of when each request is issued by VSB within each 1 second window, for 10 users and 10 requests per second (so each user performing 1 request per second) for no jitter (blue) and after this change (red):

![Screenshot 2025-03-31 at 12 56 20](https://github.com/user-attachments/assets/0a8527e6-a2a8-432a-9307-6cd239d03b9b)

Observe that requests are now ~uniformly distributed within each 1 second window.

Fixes #307.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.
