### PR TITLE
CI: Use pyproject version of black

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -10,3 +10,4 @@ jobs:
       - uses: psf/black@stable
         with:
           src: "./vsb"
+          use_pyproject: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[tool.black]
+# NOTE: When updating this version, also update `tool.poetry.group.dev.dependencies`.
+required-version = "24.4.2"
+
 [tool.poetry]
 name = "VSB"
 version = "0.1.0"
@@ -27,6 +31,7 @@ filelock = "^3.16.0"
 vsb = "vsb.main:main"
 
 [tool.poetry.group.dev.dependencies]
+# NOTE: When updating this version, also update `tool.black.required-version`.
 black = "^24.4.2"
 pytest = "^8.3.3"
 flake8 = "^7.1.1"


### PR DESCRIPTION
## Problem

Prior to this if black@stable version updates (e.g. to black v25) then we end up using a different version of black for GitHub CI action vs local development (which is still using black 24).

## Solution

Set `use_pyproject: true` so the versions are in sync.

## Type of Change

- [x] Infrastructure change (CI configs, etc)

## Test Plan

Describe specific steps for validating this change.
