### PR TITLE
Unset TERM to avoid issues with log wrapping at narrow sizes

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -118,6 +118,9 @@ def spawn_vsb_inner(
     if extra_args is None:
         extra_args = []
     env = os.environ.copy()
+    # Unset TERM to avoid issues with log wrapping at narrow sizes and
+    # parse_stats_to_json() failing to parse the stats.json path.
+    del env["TERM"]
     if extra_env:
         env.update(extra_env)
     args = [


### PR DESCRIPTION
Unset TERM in tests to avoid issues with log wrapping at narrow sizes and parse_stats_to_json() failing to parse the stats.json path.

