### PR TITLE
Testing: Add 120s timeout to each test

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2296,6 +2296,21 @@ elasticsearch = ["elasticsearch"]
 histogram = ["pygal", "pygaljs", "setuptools"]
 
 [[package]]
+name = "pytest-timeout"
+version = "2.3.1"
+description = "pytest plugin to abort hanging tests"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "pytest-timeout-2.3.1.tar.gz", hash = "sha256:12397729125c6ecbdaca01035b9e5239d4db97352320af155b3f5de1ba5165d9"},
+    {file = "pytest_timeout-2.3.1-py3-none-any.whl", hash = "sha256:68188cb703edfc6a18fad98dc25a3c61e9f24d644b0b70f33af545219fc7813e"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0"
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -2851,4 +2866,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "cfa052a341866b80485a8f370cd04378d1666104fb97847b1268c75c03b499ab"
+content-hash = "94e0014d58ec588fb1d20e83049371f9b684698b3512c8cfc29a6d94101461fe"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,13 @@ pytest = "^8.3.3"
 flake8 = "^7.2.0"
 pre-commit = "^4.2.0"
 pytest-benchmark = "^5.1.0"
+pytest-timeout = "^2.1.0"
+
+[tool.pytest.ini_options]
+# Maximum observed test runtime in CI is ~60s. Set a per-test timeout of
+# 2x (120s) to catch any stuck tests, but give some headroom in case any tests
+# slow down a bit.
+timeout = 300
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ pytest-timeout = "^2.1.0"
 # Maximum observed test runtime in CI is ~60s. Set a per-test timeout of
 # 2x (120s) to catch any stuck tests, but give some headroom in case any tests
 # slow down a bit.
-timeout = 300
+timeout = 120
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Problem

We observe intermittent CI timeouts (particulary for pod config) at the overall 15min GitHub action limit.

## Solution

Introduce a per-test timeout of 2mins to hopefully flag any stuck tests (and get stdout etc from them) before GitHub Actions cancels the entire job (where we don't see stdout)

## Type of Change

- [x] Infrastructure change (CI configs, etc)

## Test Plan

Describe specific steps for validating this change.
