### PR TITLE
Test: Use 120s timeout only for CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -54,7 +54,10 @@ jobs:
         docker compose -f docker/pgvector/docker-compose.yml up -d
     - name: Test with pytest
       run: |
-        poetry run pytest --color=yes --durations=10 --verbose
+        # Maximum observed test runtime in CI is ~60s. Set a per-test timeout of
+        # 2x (120s) to catch any stuck tests, but give some headroom in case any tests
+        # slow down a bit.
+        poetry run pytest --color=yes --durations=10 --timeout=120 --verbose
       env:
         ENVIRONMENT: ${{ matrix.environment == 'pod' && 'us-east4-gcp' || '' }}
         SERVERLESS_REGION: us-west-2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,12 +39,6 @@ pre-commit = "^4.2.0"
 pytest-benchmark = "^5.1.0"
 pytest-timeout = "^2.1.0"
 
-[tool.pytest.ini_options]
-# Maximum observed test runtime in CI is ~60s. Set a per-test timeout of
-# 2x (120s) to catch any stuck tests, but give some headroom in case any tests
-# slow down a bit.
-timeout = 120
-
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Move the per-test 120s timeout from global pytest config to CI-specific; when running locally we don't know how fast / slow the tests will run and hence this can cause spurious timeouts if enforced globally.
