### PR TITLE
Explicit close of database on end of test

### DIFF
--- a/vsb/databases/base.py
+++ b/vsb/databases/base.py
@@ -54,6 +54,10 @@ class DB(ABC):
     ) -> None:
         raise NotImplementedError
 
+    def close(sel):
+        """Performs any cleanup of the database at the end of the test run."""
+        pass
+
     @abstractmethod
     def get_batch_size(self, sample_record: Record) -> int:
         """Return the preferred batch size for a workload consisting of

--- a/vsb/databases/pgvector/pgvector.py
+++ b/vsb/databases/pgvector/pgvector.py
@@ -180,6 +180,9 @@ class PgvectorDB(DB):
         maintenance_work_mem = config.get("pgvector_maintenance_work_mem")
         self.conn.execute(f"SET maintenance_work_mem = '{maintenance_work_mem}'")
 
+    def close(self):
+        self.conn.close()
+
     def get_batch_size(self, sample_record: Record) -> int:
         # Initially use a fixed batch size of 1000; this seems to be
         # a reasonable trade-off between network / protocol overhead

--- a/vsb/databases/pinecone/pinecone.py
+++ b/vsb/databases/pinecone/pinecone.py
@@ -111,6 +111,10 @@ class PineconeDB(DB):
                 f"PineconeDB index '{self.index_name}' has incorrect metric - expected:{metric.value}, found:{index_metric}"
             )
 
+    def close(self):
+        print("Closing PineconeDB")
+        self.index.close()
+
     def get_batch_size(self, sample_record: Record) -> int:
         # Return the largest batch size possible, based on the following
         # constraints:

--- a/vsb/locustfile.py
+++ b/vsb/locustfile.py
@@ -98,6 +98,9 @@ def setup_listeners(environment, **_kwargs):
     if not isinstance(environment.runner, MasterRunner):
         environment.runner.register_message("spawn_setup", spawn_setup)
 
+@events.quitting.add_listener
+def shutdown_worker_database(environment, **_kwargs):
+    environment.database.close()
 
 def setup_environment(environment, **_kwargs):
     env = environment


### PR DESCRIPTION
This avoids some gRPC errors seen with Pinecone when we try to shutdown the overall gevent runloop while connections are still present:

```
E0000 00:00:1744379316.074424 35946925 init.cc:229] grpc_wait_for_shutdown_with_timeout() timed out.
```
