### PR TITLE
auto-calculate --users from --requests_per_sec to target QPS is achieved

### DIFF
--- a/vsb/cmdline_args.py
+++ b/vsb/cmdline_args.py
@@ -124,9 +124,11 @@ def add_vsb_cmdline_args(
             type=int,
             metavar="<int>",
             dest="num_users",
-            default=1,
-            help="Number of database clients to execute the workload. Default is %("
-            "default)s",
+            default=None,
+            help="Number of database clients to execute the workload. If not specified "
+            "and --requests_per_sec is set, the number of users is automatically "
+            "calculated to achieve the target QPS (assuming 500ms request latency). "
+            "Otherwise defaults to 1.",
         )
         general_group.add_argument(
             "--processes",

--- a/vsb/locustfile.py
+++ b/vsb/locustfile.py
@@ -109,7 +109,7 @@ def qutting_listener(environment, **_kwargs):
 def setup_environment(environment, **_kwargs):
     env = environment
     options = env.parsed_options
-    num_users = options.num_users or 1
+    num_users = options.num_users
 
     logger.debug(f"setup_environment(): runner={type(environment.runner)}")
 

--- a/vsb/main.py
+++ b/vsb/main.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import math
 import sys
 from pathlib import Path
 
@@ -40,6 +41,18 @@ def main():
     # message (and exit) if args fail validation or --help passed.
     args = parser.parse_args()
     validate_parsed_args(parser, args)
+
+    # Auto-calculate the number of users if not explicitly specified.
+    # Assuming a conservative 500ms request latency, each user can issue
+    # at most 2 requests/sec. We provision enough users to comfortably
+    # achieve the target QPS.
+    if args.num_users is None:
+        if args.requests_per_sec > 0:
+            assumed_latency = 0.5  # 500ms
+            args.num_users = max(1, math.ceil(args.requests_per_sec * assumed_latency))
+        else:
+            args.num_users = 1
+        sys.argv += ["--users", str(args.num_users)]
 
     log_base = Path(args.log_dir) / args.database
     vsb.log_dir = setup_logging(log_base=log_base, level=args.loglevel)


### PR DESCRIPTION
## Problem

When `--requests_per_sec` is set but `--users` is left at its default of 1, the benchmark often can't achieve the target QPS. Each user issues requests sequentially, so a single user's max throughput is bounded by request latency (`1 / latency`). Users have to manually calculate and set `--users` to work around this, which is error-prone.

## Solution

Auto-calculate `--users` from `--requests_per_sec` when not explicitly provided. Assuming a conservative 500ms request latency, each user can do ~2 req/s, so we provision `ceil(qps * 0.5)` users. Explicit `--users` still overrides the calculation. When `--requests_per_sec` is not set (unlimited), defaults to 1 user as before.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

- Run with `--requests_per_sec=100` and no `--users`: startup log shows `users=50`
- Run with no `--requests_per_sec` and no `--users`: startup log shows `users=1` (backward compat)
- Run with `--requests_per_sec=100 --users=10`: startup log shows `users=10` (explicit override)
- Run with `--requests_per_sec=1` and no `--users`: startup log shows `users=1` (low QPS edge case)

