### PR TITLE
Add scan_factor and max_candidates support for Pinecone dedicated rea…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,6 @@ reports/
 
 # DS_Store
 .DS_Store
+
+# Local run scripts
+run_dense_midpage.sh

--- a/vsb/cmdline_args.py
+++ b/vsb/cmdline_args.py
@@ -292,8 +292,12 @@ def add_vsb_cmdline_args(
     pinecone_group.add_argument(
         "--pinecone_namespace_name",
         type=str,
-        default="__default__",
-        help="Name of Pinecone namespace to connect to. Default is __default__.",
+        default=None,
+        help=(
+            "Name of Pinecone namespace to connect to. If not specified and the index "
+            "has exactly one namespace, that namespace is used automatically. "
+            "Otherwise defaults to '__default__'."
+        ),
         env_var="VSB__PINECONE_NAMESPACE_NAME",
     )
 
@@ -326,6 +330,29 @@ def add_vsb_cmdline_args(
         type=int,
         default=1,
         help="Number of replicas for dedicated read nodes. Default is %(default)s.",
+    )
+    pinecone_group.add_argument(
+        "--pinecone_scan_factor",
+        type=float,
+        default=None,
+        help=(
+            "Scan factor for dedicated read node indexes. Controls how much of the IVF "
+            "index is scanned to find vector candidates. Valid range: 0.5-4.0. "
+            "Default (when unset) is 4.0 (Pinecone server-side default). "
+            "Only valid with --pinecone_dedicated_read_nodes."
+        ),
+    )
+    pinecone_group.add_argument(
+        "--pinecone_max_candidates",
+        type=int,
+        default=None,
+        help=(
+            "Maximum number of candidate vectors to rerank with exact distance computation "
+            "for dedicated read node indexes. Must be >= top_k and <= 100,000. "
+            "Default (when unset) is min(top_k * 10, 1000) or top_k if top_k > 1000, "
+            "with a floor of 2500 (Pinecone server-side default). "
+            "Only valid with --pinecone_dedicated_read_nodes."
+        ),
     )
 
     opensearch_group = parser.add_argument_group(

--- a/vsb/databases/pinecone/pinecone.py
+++ b/vsb/databases/pinecone/pinecone.py
@@ -113,11 +113,38 @@ def _create_index_with_dedicated_read_nodes(
     return resp.json()
 
 
+def _describe_index_rest(
+    api_key: str,
+    index_name: str,
+    api_version: str = "2025-10",
+) -> dict:
+    """Fetch index details via REST API (exposes fields not in the SDK response)."""
+    controller_host = os.environ.get("PINECONE_CONTROLLER_HOST", "https://api.pinecone.io")
+    headers = {
+        "Api-Key": api_key,
+        "X-Pinecone-API-Version": api_version,
+    }
+    additional_headers_json = os.environ.get("PINECONE_ADDITIONAL_HEADERS")
+    if additional_headers_json:
+        try:
+            headers.update(json.loads(additional_headers_json))
+        except json.JSONDecodeError:
+            pass
+    resp = requests.get(f"{controller_host}/indexes/{index_name}", headers=headers)
+    if resp.status_code != 200:
+        raise RuntimeError(
+            f"Error fetching index '{index_name}': {resp.status_code} {resp.text}"
+        )
+    return resp.json()
+
+
 class PineconeNamespace(Namespace):
-    def __init__(self, index: GRPCIndex, namespace: str):
+    def __init__(self, index: GRPCIndex, namespace: str, scan_factor: float = None, max_candidates: int = None):
         # TODO: Support multiple namespaces
         self.index = index
         self.namespace = namespace
+        self.scan_factor = scan_factor
+        self.max_candidates = max_candidates
 
     def insert_batch(self, batch: RecordList):
         # Pinecone expects a list of dicts (or tuples).
@@ -135,11 +162,17 @@ class PineconeNamespace(Namespace):
             after=after_log(logger, logging.DEBUG),
         )
         def do_query_with_retry():
+            kwargs = {}
+            if self.scan_factor is not None:
+                kwargs["scan_factor"] = self.scan_factor
+            if self.max_candidates is not None:
+                kwargs["max_candidates"] = self.max_candidates
             return self.index.query(
                 vector=request.values,
                 top_k=request.top_k,
                 filter=request.filter,
                 namespace=self.namespace,
+                **kwargs,
             )
 
         result = do_query_with_retry()
@@ -167,13 +200,15 @@ class PineconeDB(DB):
         self.skip_populate = config["skip_populate"]
         self.overwrite = config["overwrite"]
         self.index_name = config["pinecone_index_name"]
-        self.namespace = config["pinecone_namespace_name"]
+        namespace_config = config["pinecone_namespace_name"]  # None if not specified by user
         self.use_dedicated_read_nodes = config.get(
             "pinecone_dedicated_read_nodes", False
         )
         self.dedicated_node_type = config.get("pinecone_dedicated_node_type", "b1")
         self.dedicated_shards = config.get("pinecone_dedicated_shards", 1)
         self.dedicated_replicas = config.get("pinecone_dedicated_replicas", 1)
+        self.scan_factor = config.get("pinecone_scan_factor", None)
+        self.max_candidates = config.get("pinecone_max_candidates", None)
 
         if self.index_name is None:
             # None specified, default to "vsb-<workload>"
@@ -182,6 +217,18 @@ class PineconeDB(DB):
         try:
             self.index = self.pc.Index(name=self.index_name)
             self.created_index = False
+            if namespace_config is None:
+                namespaces = list(self.index.list_namespaces())
+                if len(namespaces) == 1:
+                    self.namespace = namespaces[0]["name"]
+                    logger.info(
+                        f"PineconeDB: Auto-detected namespace '{self.namespace}' "
+                        f"(index has exactly one namespace)"
+                    )
+                else:
+                    self.namespace = "__default__"
+            else:
+                self.namespace = namespace_config
         except UnauthorizedException:
             api_key = config["pinecone_api_key"]
             masked_api_key = api_key[:4] + "*" * (len(api_key) - 8) + api_key[-4:]
@@ -219,8 +266,23 @@ class PineconeDB(DB):
 
             self.index = self.pc.Index(name=self.index_name)
             self.created_index = True
+            self.namespace = namespace_config if namespace_config is not None else "__default__"
 
         info = self.pc.describe_index(self.index_name)
+
+        if self.scan_factor is not None or self.max_candidates is not None:
+            rest_info = _describe_index_rest(self.api_key, self.index_name)
+            read_capacity = (
+                rest_info.get("spec", {})
+                .get("serverless", {})
+                .get("read_capacity", {})
+            )
+            if read_capacity.get("mode") != "Dedicated":
+                raise ValueError(
+                    f"pinecone_scan_factor and pinecone_max_candidates require an index with "
+                    f"dedicated read nodes, but '{self.index_name}' does not have them configured."
+                )
+
         index_dims = info["dimension"]
         if dimensions != index_dims:
             raise ValueError(
@@ -260,7 +322,7 @@ class PineconeDB(DB):
         return batch_size
 
     def get_namespace(self, namespace: str) -> Namespace:
-        return PineconeNamespace(self.index, self.namespace)
+        return PineconeNamespace(self.index, self.namespace, self.scan_factor, self.max_candidates)
 
     def initialize_population(self):
         # If the namespace already existed before VSB (we didn't create it) and

--- a/vsb/main.py
+++ b/vsb/main.py
@@ -42,6 +42,30 @@ def main():
     args = parser.parse_args()
     validate_parsed_args(parser, args)
 
+    # Auto-detect synthetic dimensions from an existing Pinecone index.
+    if (
+        args.database == "pinecone"
+        and args.workload.startswith("synthetic")
+        and getattr(args, "pinecone_index_name", None) is not None
+        and "--synthetic_dimensions" not in sys.argv
+    ):
+        try:
+            from pinecone.grpc import PineconeGRPC
+            pc = PineconeGRPC(args.pinecone_api_key)
+            index_info = pc.describe_index(args.pinecone_index_name)
+            index_dims = index_info["dimension"]
+            args.synthetic_dimensions = index_dims
+            sys.argv += ["--synthetic_dimensions", str(index_dims)]
+            logger.info(
+                f"Auto-detected synthetic_dimensions={index_dims} "
+                f"from index '{args.pinecone_index_name}'"
+            )
+        except Exception as e:
+            logger.warning(
+                f"Could not auto-detect dimensions from index "
+                f"'{args.pinecone_index_name}': {e}"
+            )
+
     # Auto-calculate the number of users if not explicitly specified.
     # Assuming a conservative 500ms request latency, each user can issue
     # at most 2 requests/sec. We provision enough users to comfortably


### PR DESCRIPTION
…d nodes

- Add --pinecone_scan_factor and --pinecone_max_candidates CLI args, passed through to index.query() for dedicated read node indexes
- Validate dedicated read node requirement via REST API (2025-10 version) rather than a CLI flag check, since describe_index SDK response omits read_capacity info
- Auto-detect namespace when index has exactly one namespace
- Auto-detect synthetic workload dimensions from existing Pinecone index when --synthetic_dimensions is not explicitly specified

## Problem

Describe the purpose of this change. What problem is being solved and why?

## Solution

Describe the approach you took. Link to any relevant bugs, issues, docs, or other resources.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.
