### PR TITLE
ci: add least-privilege permissions blocks to CI workflows

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -2,6 +2,9 @@ name: Lint (via Black)
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,6 +15,9 @@ on:
 concurrency:
   group: build-and-test
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds a top-level `permissions: contents: read` block to both of VSB's CI workflows (`black.yml` and `python-package.yml`). Both only read the repo — the credentialed integration tests use the `PINECONE_API_KEY` secret, which is independent of `GITHUB_TOKEN` scopes — so this narrows the default token permissions with no behavioral change.

This closes the security-hardening (least-privilege) gap from the CI rubric. VSB already has black formatting, flake8 lint, pytest, and Dependabot.

## Follow-up (tracked separately)

A CI dependency-audit gate (`pip-audit`) is worth adding but needs care: `pip-audit` currently flags **2 advisories** — `click` 8.1.7 → 8.3.3 (safe minor) and `pyarrow` 18.1.0 → **23.0.1 (a major bump)**, the latter a known deferred decision. It also needs handling for the poetry 1.8 (CI) vs 2.x lock-format difference. I've captured this as a separate task rather than bundle a risky major bump here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only hardening with no application or secret-handling changes; checkout and existing tests should behave the same.
> 
> **Overview**
> Adds a top-level **`permissions: contents: read`** block to **`black.yml`** and **`python-package.yml`**, so the default `GITHUB_TOKEN` is limited to read-only repo access instead of broader workflow defaults.
> 
> No job steps, secrets, or test behavior change; Pinecone integration still uses **`PINECONE_API_KEY`**, not expanded token scopes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dbd378befc8f9c462f3004fb51133aaeb087030. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->