### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS
+# Auto-requests review from the owners below on every pull request.
+# Docs: https://docs.github.com/articles/about-code-owners
+
+* @daverigby @jonathanzxu


### PR DESCRIPTION
Adds `.github/CODEOWNERS` so pull requests automatically request review from the appropriate owners.

Owners: `@daverigby @jonathanzxu`

Part of an org-wide rollout to ensure every public repo has code owners configured.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-style GitHub metadata with no impact on builds, deployments, or product code.
> 
> **Overview**
> Adds a new **`.github/CODEOWNERS`** file so GitHub **auto-requests review** from `@daverigby` and `@jonathanzxu` on **every pull request** via the `*` path rule.
> 
> This is repo/process configuration only; it does not change application code or runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb8c69e1580bb959360dd60d2a076af0d0130902. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->